### PR TITLE
Fix undefined variable bug in elliptic123

### DIFF
--- a/elliptic123.m
+++ b/elliptic123.m
@@ -115,7 +115,7 @@ end
 % multidimensional input reshape
 F = reshape(F,size(a1));
 E = reshape(E,size(a1));
-P = reshape(P,size(a1));
+if nargin==3, P = reshape(P,size(a1)); end
 
 end
 


### PR DESCRIPTION
The bug is
    [F,E]=elliptic123(0.5,0.9)
==>
    error: 'P' undefined near line 118, column 13
    error: called from
        elliptic123 at line 118 column 3

The fix is simple.