### PR TITLE
Post-0d09740 regression audit: GPU period fix, elliptic123 routing, scipy-free runtime, adversarial-review round

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
       - run:
           name: Run Octave tests
           command: |
-            octave --eval "addpath(fullfile(pwd, 'matlab', 'src')); cd matlab/tests; test testElliptic12; test testElliptic3; test testEllipj; test testThetaPrime; test testAgm; test testJacobiThetaEta;"
+            octave --eval "addpath(fullfile(pwd, 'matlab', 'src')); files=dir(fullfile(pwd, 'matlab', 'tests', 'test*.m')); failed=false; for k=1:numel(files); [n,nmax]=test(fullfile(files(k).folder,files(k).name),'quiet'); fprintf('%s: %d/%d\n',files(k).name,n,nmax); failed=failed || n~=nmax; end; if failed; exit(1); end"
 workflows:
   build:
     jobs:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -2,9 +2,9 @@ name: tests
 
 on:
   push:
-    paths: ["python/**"]
+    paths: ["python/**", ".github/workflows/python.yml"]
   pull_request:
-    paths: ["python/**"]
+    paths: ["python/**", ".github/workflows/python.yml"]
   release:
     types: [published]
 
@@ -13,6 +13,32 @@ defaults:
     working-directory: python
 
 jobs:
+  test-standalone:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install runtime dependencies only
+        run: pip install -e .
+      - name: Exercise public functions without SciPy
+        run: |
+          python - <<'PY'
+          import importlib.util
+          import elliptic
+
+          assert importlib.util.find_spec("scipy") is None
+          elliptic.theta(1, 0.2, 0.5)
+          elliptic.theta_prime(1, 0.2, 0.5)
+          elliptic.jacobiThetaEta(0.2, 0.5)
+          elliptic.nomeq(0.5)
+          elliptic.inversenomeq(0.04)
+          elliptic.inverselliptic2(0.5, 0.5)
+          elliptic.elliptic12i(0.7 + 0.2j, 0.5)
+          elliptic.arclength_ellipse([2.0, 3.0], [3.0, 2.0])
+          PY
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -62,7 +88,7 @@ jobs:
   publish:
     name: Build and publish to PyPI
     runs-on: ubuntu-latest
-    needs: [test, test-torch, test-jax]
+    needs: [test-standalone, test, test-torch, test-jax]
     if: github.event_name == 'release' && github.event.action == 'published'
     environment: pypi
     permissions:

--- a/docs/GPU.md
+++ b/docs/GPU.md
@@ -6,6 +6,10 @@ configuration flag.  The same source code paths work in both **MATLAB**
 (Parallel Computing Toolbox / CUDA) and **Octave** (ocl Forge package /
 OpenCL).
 
+For `elliptic3`, regular inputs run on the GPU. Inputs close to an endpoint
+pole are intentionally gathered and evaluated by the Carlson CPU path because
+fixed GPU quadrature is not accurate enough there.
+
 ---
 
 ## Benchmark results
@@ -20,9 +24,9 @@ Octave 6.4.0 · ocl 1.2.4 · CUDA driver 535, OpenCL 3.0.
 | `elliptic3` | 4 M | 2.668 s | 1.167 s (2.3×) | 0.199 s | **13.4×** |
 | `jacobiThetaEta` | 1 M | 1.460 s | 0.583 s (2.5×) | 0.494 s | **3.1×** |
 
-`elliptic3` achieves 13× because it is a pure Gauss-Legendre quadrature
-(no AGM, no sequential dependencies) — every element is completely
-independent and maps trivially to GPU threads.
+These historical `elliptic3` measurements use regular inputs, for which the
+Gauss-Legendre GPU path remains active. Every element is independent and maps
+directly to GPU threads.
 
 ### Hardware utilisation at N = 1 M
 

--- a/docs/specs/codebase-weakness-audit.md
+++ b/docs/specs/codebase-weakness-audit.md
@@ -1,5 +1,10 @@
 # Codebase Weakness Audit — Python Elliptic Library
 
+> Historical snapshot. The high-severity items and the numerical defects
+> confirmed from this list were addressed in the
+> [post-0d09740 follow-up audit](post-0d09740-regression-audit.md). Keep this
+> document as the pre-fix evidence, not as the current defect list.
+
 **Date:** 2026-04-21
 **Scope:** `/home/igor/Work/elliptic/python/elliptic/`
 **Purpose:** Identify weak or breaking points (special values, complex numbers, inf/NaN, memory, exception handling, backend tracing) to guide future implementation work.

--- a/docs/specs/post-0d09740-regression-audit.md
+++ b/docs/specs/post-0d09740-regression-audit.md
@@ -66,6 +66,26 @@ regression tests. No public function was intentionally removed.
 - A base-dependency-only public API exercise verifies that SciPy is absent and
   not imported at runtime.
 
+## Adversarial review round (2026-08-16)
+
+An independent adversarial review (Codex, cross-checked against mpmath at
+40-100 digits) of the four commits above found five material counterexamples
+that the original round missed.  All are fixed and regression-tested
+(`testEdgeCases.m` block Q, `test_edge_cases.py::TestAdversarialRound`):
+
+| Finding | Failure | Fix |
+|---|---|---|
+| `elliptic3` negative amplitude with pole in the complete integral | `0*Inf = NaN` for e.g. `Pi(-1\|.5,1)` (MATLAB) | complete-integral correction applied only where a half-period or reflection is present |
+| complex `F/E` small `m` (both ports) | A&S 17.4.11 decomposition loses `sqrt(eps/m)` digits: `F(0.2i\|1e-20)` returned 0, error 9.2e-3 at `m=1e-14` | Maclaurin series through `m^2`, switched at `m*max(1, e^(2\|psi\|)) < 1e-4`; crossover error ~2e-12 vs mpmath |
+| Weierstrass pole classification (both ports) | tolerance windows (`abs(sn) < eps^(1/3)` MATLAB; `8*eps*max(1,\|z\|)` Python) returned `Inf` for the finite `P(1e-16) = 1e32` | pole only at the exact lattice point (`z_reduced == 0` / `sn == 0`), per the DLMF 23.9.2 Laurent expansion |
+| inverse nome small `q` (both ports) | Python bisection had a `2^-64` absolute floor (`m(1e-30)` off by 9 orders); MATLAB tables documented-unreliable outside `[1e-5, 0.76]` | DLMF 20.9.1 closed form `m = (theta2/theta3)^4` with the `q^(1/4)` factor kept outside the ratio; exact at every scale |
+| Carlson `RC` scale invariance (Python) | absolute branch tolerance sent small-scale inputs down the degenerate branch: `RC(1e-20,2e-20)` off 27%, contaminating `RJ` | relative branch selection; homogeneity `RF,RC ~ lambda^(-1/2)`, `RD,RJ ~ lambda^(-3/2)` now tested at `lambda = 1e+/-20` |
+
+Also from that round: reversed arc intervals are now signed for circles and
+ellipses alike; DLMF citations corrected (19.25.14 for incomplete third kind,
+19.25.5/19.25.9 for F/E); nondegenerate `ellipticBD` anchors at
+`m = 0.2, 0.7, 0.999`.
+
 ## Deliberate limits and residual risk
 
 - CUDA/OpenCL hardware was not available during this audit. GPU source paths
@@ -79,3 +99,13 @@ regression tests. No public function was intentionally removed.
   complex input explicitly instead of silently discarding data.
 - `elliptic3` deliberately rejects real paths that cross a third-kind pole;
   Cauchy principal-value continuation is not implemented.
+- Jacobi phase reduction is double precision: the residual phase carries an
+  absolute uncertainty ~`|u|*eps`, so `ellipj` holds full precision to
+  `|u| ~ 1e12`, degrades linearly beyond, and has lost the phase entirely by
+  `|u| ~ 1e16`.  Every double-precision implementation (MATLAB's and SciPy's
+  included) shares this bound; extended-precision reduction would need K(m)
+  to ~32 digits.
+- `elliptic12i` follows the A&S 17.4.11 real-decomposition branch: on
+  `Re u = pi/2` above the branch point, `Re F = K(m)`, which diverges as
+  `m -> 1`.  mpmath/Mathematica may return values on a different sheet
+  there; the convention is now documented in both ports.

--- a/docs/specs/post-0d09740-regression-audit.md
+++ b/docs/specs/post-0d09740-regression-audit.md
@@ -1,0 +1,81 @@
+# Post-0d09740 Regression and Data-Integrity Audit
+
+**Date:** 2026-07-28  
+**Baseline:** `0d09740` on `master`  
+**Trigger:** [issue #35](https://github.com/moiseevigor/elliptic/issues/35) and its initial [patch](https://github.com/moiseevigor/elliptic/commit/0d09740)  
+**Scope:** MATLAB/Octave and Python implementations, numerical special values,
+backend dispatch, data-shape preservation, packaging, and CI coverage.
+
+## Assessment
+
+The initial patch added useful special-value tests, but it did not fully close
+the regression class. In particular, the issue #35 phase-reduction fix was
+missing from the MATLAB GPU implementation, and a private stale copy inside
+`elliptic123.m` could still bypass the repaired public implementation. The
+audit also found independent numerical cancellation, pole-handling,
+backend-dispatch, and CI-coverage defects.
+
+All fixes below are kept atomic at the function boundary and covered by
+regression tests. No public function was intentionally removed.
+
+## Confirmed findings and fixes
+
+| Severity | Area | Failure and data impact | Fix |
+|---|---|---|---|
+| Critical | MATLAB GPU `elliptic12` | The GPU path did not apply the quasi-period correction from issue #35, so phases outside the principal interval could return the wrong branch. | Apply the same exact period reduction and complete-integral correction as the serial path; add GPU regression coverage. |
+| High | `elliptic123` dispatch | Stale private `elliptic12i`/`elliptic12ic` copies shadowed the repaired public implementation and preserved old behavior. | Retire the private names so `elliptic123` routes through the maintained public function; add routing parity tests. |
+| High | Python runtime dependencies | `theta`, nome, inverse, and complex functions imported SciPy although SciPy was not declared as a runtime dependency. A base installation failed only when those public functions were called. | Replace runtime SciPy calls with backend-native theta series, Carlson/AGM forms, and fixed-iteration inverse solvers; add a SciPy-free install job. |
+| High | `elliptic12`, `m=1` | Reducing the phase before checking the singularity hid crossed first-kind poles (`F(pi,1)` became zero) and under-counted `E` after the first quadrant. | Detect pole crossings from the original phase and restore the full quasi-period contribution. |
+| High | `ellipticBD`, small `m` | `(K-E)/m` and `(D-B)/m` catastrophically cancelled. At `m=1e-20`, valid finite limits became `D=0` and an order-`1e20` wrong `S`. | Compute `D` directly with Carlson `RD`, derive `B` from `RF-RD/3`, and use a convergent series for `S` near zero in both languages. |
+| High | `elliptic3`, near `n=1` | Fixed quadrature lost roughly seven decimal digits near the third-kind endpoint pole. Negative phases crossing an interior pole were not consistently rejected in Python. | Use Carlson `RF/RJ` throughout Python; use a MATLAB/Octave hybrid that keeps quadrature on regular inputs and switches near poles; validate pole crossings using `abs(phi)`. |
+| High | `ellipj`, extreme inputs | Clipping valid parameters changed representable data near `m=0` and `m=1`; large phases entered the amplified Landen recursion directly and could produce order-one errors. | Preserve every interior parameter exactly, reduce by `2K` before descent, reconstruct quasi-period signs, and use stable `dn` and `sech` formulas. |
+| High | Weierstrass functions | A magnitude heuristic labelled finite near-pole values as infinity (`P(1e-11)` became `Inf`), complex inputs silently lost their imaginary part, and zeta/sigma forced NumPy arrays. | Detect actual lattice points using reduced periods and ULP-scale tolerance, explicitly reject unsupported complex inputs, and keep zeta/sigma backend-native. |
+| High | JAX/PyTorch dispatch | Python control flow, NumPy casts, and scalar flattening broke tracing or moved public results off device in complex, inverse, theta, Jacobi EDJ, Weierstrass, and ellipse helpers. | Replace value-dependent Python branches with masked array expressions and fixed iteration counts; preserve the originating array namespace and shape. |
+| Medium | Jacobi theta endpoints | `theta(1,v,0)` returned `sin(v)` instead of zero; tiny valid `m` values were collapsed to the endpoint; representable values near `m=1` returned NaN. | Evaluate native theta series with exact endpoint overrides and no arbitrary endpoint clipping. |
+| Medium | MATLAB grouping | `uniquetol(...,1e-11)` treated distinct `m` values as identical and silently substituted one result for another. A `5e-12` parameter difference produced a `1.69e-9` vector/scalar discrepancy. | Group exact duplicates only in `elliptic12` and `ellipj`; add a no-substitution regression. |
+| Medium | MATLAB complex integral | `elliptic12i` divided by `m` at the exact `m=0` endpoint. | Use a safe internal denominator and restore the analytic `m=0` values exactly. |
+| Medium | Carlson `RJ` tracing | Public eager validation converted JAX tracers to NumPy and failed before evaluation; an unselected `RC` branch could still emit invalid arithmetic. | Restrict exception-producing validation to eager NumPy inputs and make internal masked arguments safe. |
+| Medium | Ellipse helper | Public inputs were cast to Python `float`, rejecting arrays, Torch tensors, and JAX tracers and losing broadcast shape. | Implement elementwise backend-native broadcasting, explicit NumPy domain errors, and masked invalid values for traced execution. |
+| Medium | CI coverage | Octave CI ran only 6 of 15 test files. Torch/JAX jobs installed their backends but no tests passed those arrays. The release path had no base-dependency-only check. | Discover every `test*.m`, add real NumPy/Torch/JAX dispatch tests, add a SciPy-free standalone job, and make publishing depend on all of them. |
+
+## Numerical and differential checks
+
+- Real `F` and `E` were compared over broad random phases, including many
+  quasi-periods, against independent reference implementations; observed
+  absolute discrepancies were about `1.3e-12` or smaller.
+- Real third-kind values were compared to independent Carlson `RF/RJ`
+  references; observed relative discrepancies were about `2.5e-15`.
+- Two hundred random complex `F`, `E`, and Jacobi `sn` samples were compared
+  with 50-digit `mpmath` values; the largest observed discrepancy was about
+  `5e-14`.
+- The Weierstrass differential equation residual was checked at random regular
+  points; the largest observed relative residual was about `4.5e-15`.
+- The large-phase `ellipj` regression at
+  `u=1,000,000.123`, `m=nextafter(1,0)` was checked against a 70-digit
+  `mpmath` reference in both languages.
+
+## Automated verification
+
+- Python default environment: **451 passed, 1 skipped**. The skip is the
+  optional JAX-only test when JAX is not installed.
+- Python with both JAX and PyTorch installed: **458 passed**.
+- Dedicated backend matrix: **10 passed**, covering NumPy, PyTorch, and JAX;
+  JAX compiles the core paths and traces the larger fixed-iteration graphs.
+- Octave: **220/220 test blocks passed** across all 16 `test*.m` files.
+- Python byte-compilation and whitespace/error checks passed.
+- A base-dependency-only public API exercise verifies that SciPy is absent and
+  not imported at runtime.
+
+## Deliberate limits and residual risk
+
+- CUDA/OpenCL hardware was not available during this audit. GPU source paths
+  and dispatch tests were reviewed, and CPU/Octave tests passed, but the
+  corrected MATLAB/Octave GPU kernels still require hardware execution before
+  a release claim can include direct GPU validation.
+- MATLAB Parallel Computing Toolbox was not available. Octave reported its
+  parallel-package skips; serial behavior and parallel dispatch code were
+  reviewed, but a real multi-worker run remains release validation work.
+- Weierstrass functions currently support real inputs only. They now reject
+  complex input explicitly instead of silently discarding data.
+- `elliptic3` deliberately rejects real paths that cross a third-kind pole;
+  Cauchy principal-value continuation is not implemented.

--- a/docs/wiki/Elliptic-Integrals.md
+++ b/docs/wiki/Elliptic-Integrals.md
@@ -160,7 +160,7 @@ The library provides the AGM function directly:
 
 ## Carlson's Method
 
-The conventional methods for computing elliptic integrals are Gauss and Landen transformations, which converge quadratically and work well for elliptic integrals of the first and second kinds. Unfortunately they suffer from loss of significant digits for the third kind. Carlson's algorithm provides a unified method for all three kinds with satisfactory precision. The third kind integral in this library uses a Gauss-Legendre 10-point quadrature instead.
+The conventional methods for computing elliptic integrals are Gauss and Landen transformations, which converge quadratically and work well for elliptic integrals of the first and second kinds. Unfortunately they suffer from loss of significant digits for the third kind. Carlson's algorithm provides a unified method for all three kinds with satisfactory precision. Python evaluates the third kind directly with Carlson RF/RJ forms. MATLAB/Octave uses a hybrid: vectorised 20-node Gauss-Legendre quadrature on regular inputs and Carlson RF/RJ near endpoint poles, where fixed quadrature loses precision.
 
 ---
 

--- a/docs/wiki/elliptic.md
+++ b/docs/wiki/elliptic.md
@@ -148,7 +148,7 @@ _See also_ `ELLIPKE`, `ELLIPJ`, `ELLIPTIC3`, `THETA`.
 
 [ELLIPTIC3](https://github.com/moiseevigor/elliptic/blob/master/src/elliptic3.m) evaluates incomplete elliptic integral of the third kind `Pi = ELLIPTIC3(U,M,C)` where `U` is a phase in radians, `0 < M < 1` is the module and `0 < C < 1` is a parameter.
 
-`ELLIPTIC3` uses Gauss-Legendre 10 points quadrature template described in [3] to determine the value of the Incomplete Elliptic Integral of the Third Kind (see [1, 2]).
+`ELLIPTIC3` uses vectorised 20-node Gauss-Legendre quadrature on regular inputs and switches to Carlson RF/RJ symmetric forms near endpoint poles. This preserves the fast path while avoiding fixed-quadrature precision loss as `M` or `C` approaches one.
 
 **General definition:**
 ```

--- a/matlab/src/ellipj.m
+++ b/matlab/src/ellipj.m
@@ -9,6 +9,13 @@ function [sn,cn,dn,am] = ellipj(u,m,tol)
 %   [Sn,Cn,Dn,Am] = ELLIPJ(U,M,TOL) computes the elliptic functions to
 %   the accuracy TOL instead of the default TOL = EPS.
 %
+%   Accuracy limit for large arguments: the phase is reduced modulo 2K in
+%   double precision, so the residual phase carries an absolute uncertainty
+%   of about |U|*eps.  Full precision holds for |U| up to ~1e12; beyond
+%   that the error grows linearly and by |U| ~ 1e16 the phase is lost
+%   entirely.  This bound is shared by every double-precision
+%   implementation (including MATLAB's and SciPy's own ELLIPJ).
+%
 %   Some definitions of the Jacobi elliptic functions use the modulus
 %   k instead of the parameter m.  They are related by m = k^2.
 %

--- a/matlab/src/ellipj.m
+++ b/matlab/src/ellipj.m
@@ -74,12 +74,10 @@ end
 
 I = find(m ~= 1 & m ~= 0);
 if ~isempty(I)
-    % Use standard uniquetol for numerical precision issues
-    % This is the recommended MATLAB approach since R2015a
+    % Preserve distinct parameters exactly; tolerance grouping is a silent
+    % data substitution and is particularly damaging near m=1.
     m_vals = m(I);
-    tol_unique = 1e-11;
-
-    [mu, ~, K] = uniquetol_compat(m_vals, tol_unique);
+    [mu, ~, K] = unique(m_vals);
     K = K(:).';
 
     mumax = length(mu);
@@ -109,8 +107,15 @@ if ~isempty(I)
 	end
 
     mmax = length(I);
+    % Use the platform complete integral for reduction.  Deriving K from the
+    % tolerance-stopped AGM is adequate for small u but its last-bit error is
+    % multiplied by the period count for large u, especially near m=1.
+    K_unique = carlsonRF(zeros(size(mu)), 1-mu, ones(size(mu)));
+    K_vals = K_unique(K);
+    period = floor((u(I) + K_vals) ./ (2 .* K_vals));
+    u_reduced = u(I) - 2 .* period .* K_vals;
 	phin = zeros(1,mmax);
-	phin(:) = (2 .^ n(K)).*a(i,K).*u(I);
+	phin(:) = (2 .^ n(K)).*a(i,K).*u_reduced;
 	while i > 1
         i = i - 1;
         mask = n(K) >= i;
@@ -118,10 +123,11 @@ if ~isempty(I)
           phin(mask) = 0.5*(asin(c(i+1,K(mask)).*sin(phin(mask))./a(i+1,K(mask))) + phin(mask));
         end
 	end
-	am(I) = phin;
-	sn(I) = sin(phin);
-	cn(I) = cos(phin);
-	dn(I) = sqrt(1 - m(I).*sin(phin).^2);
+    quasi_sign = 1 - 2 .* mod(period, 2);
+	am(I) = phin + period .* pi;
+	sn(I) = quasi_sign .* sin(phin);
+	cn(I) = quasi_sign .* cos(phin);
+	dn(I) = sqrt((1 - m(I)) + m(I).*cn(I).^2);
 end
 
 % Special cases: m = {0, 1}
@@ -215,18 +221,27 @@ function [sn,cn,dn,am] = gpu_ellipj(u, m, tol)
             n(mask) = ii - 1;
         end
 
+        % Reduce by the 2K quasi-period before the amplified Landen phase.
+        % This mirrors the serial path and prevents large-argument phase loss.
+        a_final = gather(a(:,ii));
+        K_vals = carlsonRF(zeros(size(mu)), 1-mu, ones(size(mu)));
+        period = floor((u(I) + K_vals) ./ (2 .* K_vals));
+        u_reduced = u(I) - 2 .* period .* K_vals;
+
         % Ascending Landen back-substitution with multiplicative masking
-        phin = gpuArray((2 .^ n) .* gather(a(:,ii)) .* u(I));
+        phin = gpuArray((2 .^ n) .* a_final .* u_reduced);
         for jj = ii-1:-1:1
             active = gpuArray(double(n >= jj));
             phin_new = 0.5*(asin(c(:,jj+1).*sin(phin)./a(:,jj+1)) + phin);
             phin = phin + active .* (phin_new - phin);
         end
 
-        am(I) = gather(phin);
-        sn(I) = gather(sin(phin));
-        cn(I) = gather(cos(phin));
-        dn(I) = sqrt(1 - m(I) .* gather(sin(phin)).^2);
+        quasi_sign = 1 - 2 .* mod(period, 2);
+        phin_cpu = gather(phin);
+        am(I) = phin_cpu + period .* pi;
+        sn(I) = quasi_sign .* sin(phin_cpu);
+        cn(I) = quasi_sign .* cos(phin_cpu);
+        dn(I) = sqrt((1 - m(I)) + m(I) .* cn(I).^2);
     end
 
     % Special cases: m = {0, 1}

--- a/matlab/src/elliptic12.m
+++ b/matlab/src/elliptic12.m
@@ -84,12 +84,10 @@ m(m<eps) = 0;
 
 I = find(m ~= 1 & m ~= 0);
 if ~isempty(I)
-    % Use standard uniquetol for numerical precision issues
-    % This is the recommended MATLAB approach since R2015a
+    % Group exact duplicates only.  uniquetol(1e-11) silently substituted a
+    % neighbouring parameter and caused errors up to 1e-9 near m=1.
     m_vals = m(I);
-    tol_unique = 1e-11;
-
-    [mu, ~, K] = uniquetol_compat(m_vals, tol_unique);
+    [mu, ~, K] = unique(m_vals);
     K = K(:).';
     mumax = length(mu);
     signU = sign(u(I));
@@ -259,7 +257,15 @@ function [F,E,Z] = gpu_elliptic12(u, m, tol)
         e_vals = 2 .^ (0:mn-1);
         e = gpuArray(e_vals(max(n-1, 1))(:));  % column, e(j)=e_vals(n(j)-1)
 
-        phin = gpuArray(signU .* u(I));
+        % Mirror the serial issue-#35 fix: reduce the phase before the
+        % Landen descent and restore 2*k*K afterwards.  The previous GPU
+        % branch still evaluated the unreduced phase and therefore retained
+        % the v4.1.0 regression even after the CPU path was repaired.
+        K_vals = pi ./ (2 .* a(:,mn));
+        u_work = signU .* u(I);
+        k_per = floor(u_work ./ pi);
+        phin = gpuArray(u_work - k_per .* pi);
+        K_per = 2 .* gpuArray(k_per) .* K_vals;
         C    = gpuArray(zeros(mmax, 1));
         Cp   = gpuArray(zeros(mmax, 1));
         c2   = c .^ 2;
@@ -273,7 +279,7 @@ function [F,E,Z] = gpu_elliptic12(u, m, tol)
             Cp = Cp + active .* c(:,jj+1) .* sin(phin);
         end
 
-        Ff = phin ./ (a(:,mn) .* e * 2);
+        Ff = phin ./ (a(:,mn) .* e * 2) + K_per;
         F(I) = gather(Ff)                    .* signU;
         Z(I) = gather(Cp)                    .* signU;
         E(I) = gather(Cp + (1 - 0.5*C) .* Ff) .* signU;

--- a/matlab/src/elliptic123.m
+++ b/matlab/src/elliptic123.m
@@ -523,7 +523,7 @@ end
 
 
 
-function [Fi,Ei,Zi] = elliptic12i(u,m,tol)
+function [Fi,Ei,Zi] = elliptic12i_legacy(u,m,tol)
 
 % ELLIPTIC12i evaluates the Incomplete Elliptic Integrals
 % of the First, Second Kind and Jacobi's Zeta Function for the complex
@@ -630,8 +630,8 @@ end
 lambda = (-1).^floor(phi/pi*2).*lambda + pi*ceil(phi/pi-0.5+eps);
 mu     = sign(psi).*real(mu);
 
-[F1(:),E1(:)] = elliptic12ic(lambda, m, tol);
-[F2(:),E2(:)] = elliptic12ic(mu, 1-m, tol);
+[F1(:),E1(:)] = elliptic12ic_legacy(lambda, m, tol);
+[F2(:),E2(:)] = elliptic12ic_legacy(mu, 1-m, tol);
 
 % complex values of elliptic integral of the first kind
 Fi = F1 + sqrt(-1)*F2;
@@ -655,7 +655,7 @@ end
 
 % END FUNCTION ELLIPTIC12i()
 
-function [F,E,Z] = elliptic12ic(u,m,tol)
+function [F,E,Z] = elliptic12ic_legacy(u,m,tol)
 %
 % Bug fix for the elliptic12 in the main distribution.
 % This function should disappear when the fixes appear there.
@@ -681,12 +681,9 @@ if any(m < 0) || any(m > 1), error('M must be in the range 0 <= M <= 1.'); end
 
 I = uint32( find(m ~= 1 & m ~= 0) );
 if ~isempty(I)
-    % Use standard uniquetol for numerical precision issues
-    % This is the recommended MATLAB approach since R2015a
+    % Legacy implementation retained only for historical comparison.
     m_vals = m(I);
-    tol_unique = 1e-11;
-
-    [mu, ~, K] = uniquetol_compat(m_vals, tol_unique);
+    [mu, ~, K] = unique(m_vals);
     K = uint32(K(:).');  % Ensure K is a row vector
     mumax = length(mu);
     signU = sign(u(I));
@@ -942,4 +939,3 @@ if ~isempty(im)
 end
 
 end
-

--- a/matlab/src/elliptic12i.m
+++ b/matlab/src/elliptic12i.m
@@ -10,6 +10,13 @@ function [Fi,Ei,Zi] = elliptic12i(u,m,tol)
 %   ELLIPTIC12i uses the function ELLIPTIC12 to evaluate the values of
 %   corresponding integrals.
 %
+%   Branch convention: values follow the A&S 17.4.11 real decomposition
+%   F(phi+i*psi|m) = F(lambda|m) + i*F(mu|1-m).  On the line phi = pi/2
+%   (above the branch point pi/2 + i*acosh(1/sqrt(m))) this fixes
+%   Re F = K(m), which diverges as m -> 1.  Other systems (Mathematica,
+%   mpmath) may return values on a different sheet there; both satisfy
+%   the defining differential relation.
+%
 %   Example:
 %   [phi1,phi2] = meshgrid(-2*pi:3/20:2*pi, -2*pi:3/20:2*pi);
 %   phi = phi1 + phi2*i;
@@ -129,11 +136,23 @@ Ei(:) = Ei(:) + E1(:) + sqrt(-1)*(-E2(:) + F2(:));
 % complex values of zeta function
 Zi(:) = Ei(:) - Ee(:)./K(:).*Fi(:);
 
-% Exact elementary limit at m=0.  The transformation above contains a
-% division by m and previously returned NaN for this documented endpoint.
-m0 = find(m == 0);
-Fi(m0) = u(m0);
-Ei(m0) = u(m0);
-Zi(m0) = 0;
+% Small-m Maclaurin series (through m^2).  The A&S 17.4.11 decomposition
+% loses ~sqrt(eps/m) digits as m -> 0 (0.2 absolute at m = 1e-16); the
+% series is exact there and covers m = 0 itself:
+%   F = u + m(u/4 - sin2u/8) + m^2(9u/64 - 3sin2u/32 + 3sin4u/256) + O(m^3)
+%   E = u - m(u/4 - sin2u/8) - m^2(3u/64 -  sin2u/32 +  sin4u/256) + O(m^3)
+% Valid while |m sin^2 u| is small: switch on m*max(1, e^(2|psi|)) < 1e-4,
+% where the crossover error is ~2e-12 (measured against 40-digit mpmath).
+m_eff = m .* max(1, exp(2*abs(psi)));
+sm = find(m_eff < 1e-4);
+if ~isempty(sm)
+    uu = u(sm);  mm = m(sm);    % original u: phi carries the +eps nudge
+    s2 = sin(2*uu);  s4 = sin(4*uu);
+    Fs = uu + mm.*(uu/4 - s2/8) + mm.^2.*(9*uu/64 - 3*s2/32 + 3*s4/256);
+    Es = uu - mm.*(uu/4 - s2/8) - mm.^2.*(3*uu/64 - s2/32 + s4/256);
+    Fi(sm) = Fs;
+    Ei(sm) = Es;
+    Zi(sm) = Es - Ee(sm)./K(sm).*Fs;
+end
 
 % END FUNCTION ELLIPTIC12i()

--- a/matlab/src/elliptic12i.m
+++ b/matlab/src/elliptic12i.m
@@ -99,7 +99,9 @@ lambda = acot( sqrt(X1) );
 % than from LAMBDA: at phi = pi/2 the root X1 underflows, LAMBDA rounds to
 % exactly pi/2 and cot(LAMBDA) loses every digit of it -- that is what used
 % to drop the whole imaginary part of the result there.
-mu = atan( sqrt( max((ratio - 1)./m, 0) ) );
+m_calc = m;
+m_calc(m_calc == 0) = 1;
+mu = atan( sqrt( max((ratio - 1)./m_calc, 0) ) );
 
 % change of variables taking into account periodicity ceil to the right
 lambda = (-1).^floor(phi/pi*2).*lambda + pi*ceil(phi/pi-0.5+eps);
@@ -126,5 +128,12 @@ Ei(:) = Ei(:) + E1(:) + sqrt(-1)*(-E2(:) + F2(:));
 [K,Ee] = ellipke(m);
 % complex values of zeta function
 Zi(:) = Ei(:) - Ee(:)./K(:).*Fi(:);
+
+% Exact elementary limit at m=0.  The transformation above contains a
+% division by m and previously returned NaN for this documented endpoint.
+m0 = find(m == 0);
+Fi(m0) = u(m0);
+Ei(m0) = u(m0);
+Zi(m0) = 0;
 
 % END FUNCTION ELLIPTIC12i()

--- a/matlab/src/elliptic3.m
+++ b/matlab/src/elliptic3.m
@@ -46,9 +46,18 @@ if any(u(:) < 0) || any(u(:) > pi/2)
     r     = ua - k_per .* pi;            % in [0, pi)
     refl  = r > pi/2;
     ur    = r;  ur(refl) = pi - r(refl); % in [0, pi/2]
-    Pcpl  = elliptic3(pi/2 + zeros(size(u)), m, c);
     Pred  = elliptic3(ur, m, c);
-    Pi    = signU .* (2 .* k_per .* Pcpl + refl .* (2 .* Pcpl) + (1 - 2 .* refl) .* Pred);
+    % Complete-integral correction only where a half-period or reflection
+    % actually applies: when the complete integral is a pole (m = 1 or
+    % c = 1), an unconditional 2*k_per*Pcpl forms 0*Inf = NaN for phases
+    % that never cross it (e.g. plain negative amplitudes).
+    corr = zeros(size(ur));
+    idx  = (k_per > 0) | refl;
+    if any(idx(:))
+        Pcpl = elliptic3(pi/2 + zeros(size(u)), m, c);
+        corr(idx) = 2 .* k_per(idx) .* Pcpl(idx) + 2 .* refl(idx) .* Pcpl(idx);
+    end
+    Pi = signU .* (corr + (1 - 2 .* refl) .* Pred);
     return;
 end
 
@@ -90,7 +99,7 @@ I = find(u==pi/2 & m==1 | u==pi/2 & c==1);
 
 % Hybrid evaluator.  The 20-node rule is full precision while both endpoint
 % denominators stay >= 0.25; nearer a pole, switch only those elements to the
-% Carlson form (DLMF 19.25.1).  This retains the vectorised fast path without
+% Carlson form (DLMF 19.25.14).  This retains the vectorised fast path without
 % the previous seven-digit loss as c approached 1.
 s = sin(u);
 s2 = s.^2;

--- a/matlab/src/elliptic3.m
+++ b/matlab/src/elliptic3.m
@@ -3,9 +3,10 @@ function Pi = elliptic3(u,m,c);
 %   Pi = ELLIPTIC3(U,M,C) where U is a phase in radians, 0<M<1 is
 %   the module and 0<C<1 is a parameter.
 %
-%   ELLIPTIC3 uses Gauss-Legendre 10 points quadrature template
-%   described in [3] to determine the value of the Incomplete Elliptic
-%   Integral of the Third Kind (see [1, 2]).
+%   ELLIPTIC3 uses 20-node Gauss-Legendre quadrature away from endpoint
+%   singularities and Carlson RF/RJ forms near a pole.  The hybrid avoids
+%   the quadrature's loss of precision as C or M approaches one while
+%   retaining its vectorised fast path for regular inputs.
 %
 %   Pi(u,m,c) = int(1/((1 - c*sin(t)^2)*sqrt(1 - m*sin(t)^2)), t=0..u)
 %
@@ -62,9 +63,13 @@ end
 
 Pi = zeros(size(u));
 
-% GPU dispatch: move computation to GPU if enabled and available
+% GPU dispatch: the legacy fixed quadrature is retained only away from the
+% endpoint singularities.  Near a pole it loses several digits, so fall back
+% to the Carlson CPU core below.
 N_el = numel(u);
-if has_gpu()
+gpu_regular = all((1 - c(:).*sin(u(:)).^2) >= 0.25) && ...
+              all((1 - m(:).*sin(u(:)).^2) >= 0.25);
+if has_gpu() && gpu_regular
     Pi = gpu_elliptic3(u, m, c);
     return;
 end
@@ -81,27 +86,60 @@ m = m(:).';    % make a row vector
 u = u(:).';
 c = c(:).';
 
-I = find( u==pi/2 & m==1 | u==pi/2 & c==1 );
+I = find(u==pi/2 & m==1 | u==pi/2 & c==1);
 
-t = [ 0.9931285991850949,  0.9639719272779138,...            % Base points
-      0.9122344282513259,  0.8391169718222188,...            % for Gauss-Legendre integration
-      0.7463319064601508,  0.6360536807265150,...
-      0.5108670019508271,  0.3737060887154195,...
-      0.2277858511416451,  0.07652652113349734 ];
-w = [ 0.01761400713915212, 0.04060142980038694,...           % Weights
-      0.06267204833410907, 0.08327674157670475,...           % for Gauss-Legendre integration
-      0.1019301198172404,  0.1181945319615184,...
-      0.1316886384491766,  0.1420961093183820,...
-      0.1491729864726037,  0.1527533871307258  ];
+% Hybrid evaluator.  The 20-node rule is full precision while both endpoint
+% denominators stay >= 0.25; nearer a pole, switch only those elements to the
+% Carlson form (DLMF 19.25.1).  This retains the vectorised fast path without
+% the previous seven-digit loss as c approached 1.
+s = sin(u);
+s2 = s.^2;
+co = cos(u);
+d2 = 1 - m.*s2;
+p = 1 - c.*s2;
+danger = (d2 < 0.25) | (p < 0.25);
+P = zeros(size(u));
 
-P = 0;  i = 0;
-while i < 10
-    i  = i + 1;
-    c0 = u.*t(i)/2;
-    P  = P + w(i).*(g(u/2+c0,m,c) + g(u/2-c0,m,c));
+regular = find(~danger);
+if ~isempty(regular)
+    t = [0.9931285991850949, 0.9639719272779138, ...
+         0.9122344282513259, 0.8391169718222188, ...
+         0.7463319064601508, 0.6360536807265150, ...
+         0.5108670019508271, 0.3737060887154195, ...
+         0.2277858511416451, 0.07652652113349734];
+    w = [0.01761400713915212, 0.04060142980038694, ...
+         0.06267204833410907, 0.08327674157670475, ...
+         0.1019301198172404,  0.1181945319615184, ...
+         0.1316886384491766,  0.1420961093183820, ...
+         0.1491729864726037,  0.1527533871307258];
+    ur = u(regular);
+    mr = m(regular);
+    cr = c(regular);
+    Pr = zeros(size(ur));
+    for jj = 1:10
+        c0 = ur .* t(jj) ./ 2;
+        Pr = Pr + w(jj) .* (g(ur./2+c0, mr, cr) + g(ur./2-c0, mr, cr));
+    end
+    P(regular) = ur ./ 2 .* Pr;
 end
-P = u/2.*P;
-Pi(:) = P;                                                   % Incomplete elliptic integral of the third kind
+
+% Keep the eager Carlson evaluation finite at endpoint poles; those outputs
+% are replaced by Inf below.
+near = find(danger);
+if ~isempty(near)
+    c_eval = c(near);
+    d2_eval = d2(near);
+    p_eval = p(near);
+    endpoint = (u(near)==pi/2 & (m(near)==1 | c(near)==1));
+    c_eval(endpoint) = 0;
+    d2_eval(endpoint) = 1;
+    p_eval(endpoint) = 1;
+    RF = carlsonRF(co(near).^2, d2_eval, ones(size(near)));
+    RJ = carlsonRJ(co(near).^2, d2_eval, ones(size(near)), p_eval);
+    P(near) = s(near).*RF + c_eval.*s(near).^3.*RJ./3;
+end
+P(s == 0) = 0;
+Pi(:) = P;
 
 % special values u==pi/2 & m==1 | u==pi/2 & c==1
 Pi(I) = inf;

--- a/matlab/src/ellipticBD.m
+++ b/matlab/src/ellipticBD.m
@@ -16,16 +16,12 @@ function [B, D, S] = ellipticBD(m)
 %
 %   Algorithm — Carlson symmetric forms (DLMF §19.25):
 %
-%       B(m) = (1/2) · K(m) + (1/2) · E(m) / (1−m)   -- well-conditioned
+%       K(m) = RF(0, 1−m, 1)
+%       D(m) = RD(0, 1−m, 1) / 3
+%       B(m) = K(m) − D(m)
 %
-%   Actually uses:
-%       [K, E] = ellipke(m)
-%       D(m) = (K − E) / m
-%       B(m) = K − D
-%       S(m) = (D − B) / m = (2D − K) / m
-%
-%   This avoids subtraction of nearly equal numbers via ellipke's own
-%   internal cancellation-safe algorithm.
+%   The expression S=(D−B)/m still cancels as m→0, so a convergent
+%   binomial/integral series is used for |m|<10⁻².
 %
 %   M may be a scalar or array. All elements must satisfy 0 <= m < 1.
 %   At m = 0: B = D = π/4.
@@ -74,21 +70,27 @@ end
 % -----------------------------------------------------------------------
 function [B, D, S] = ellipticBD_core(m, origSize)
 %ELLIPTICBD_CORE  Vectorised serial evaluation (row-vector input).
-[K, E] = ellipke(m);
-mc = 1 - m;
-
-% D = (K − E) / m, handle m = 0 via L'Hôpital: D(0) = π/4
-D = zeros(size(m));
-nz = (m ~= 0);
-D(nz) = (K(nz) - E(nz)) ./ m(nz);
-D(~nz) = pi / 4;
-
+zero = m .* 0;
+one = zero + 1;
+K = carlsonRF(zero, 1-m, one);
+D = carlsonRD(zero, 1-m, one) ./ 3;
 B = K - D;
 
-% S = (D − B) / m = (2D − K) / m, handle m = 0 via L'Hôpital: S(0) = π/16
-S = zeros(size(m));
-S(nz) = (D(nz) - B(nz)) ./ m(nz);
-S(~nz) = pi / 16;
+% S = (D-B)/m is catastrophically cancelling near m=0.  Evaluate the
+% binomial/integral series there instead.
+S_series = zero;
+for kk = 1:8
+    ck  = nchoosek(2*kk, kk) / 4^kk;
+    Ik  = pi * nchoosek(2*kk, kk) / (2 * 4^kk);
+    Ik1 = pi * nchoosek(2*kk+2, kk+1) / (2 * 4^(kk+1));
+    S_series = S_series + ck * (2*Ik1 - Ik) .* m.^(kk-1);
+end
+m_safe = m;
+m_safe(m_safe == 0) = 1;
+S_direct = (D - B) ./ m_safe;
+S = S_direct;
+small = abs(m) < 1e-2;
+S(small) = S_series(small);
 
 B = reshape(B, origSize);
 D = reshape(D, origSize);

--- a/matlab/src/inversenomeq.m
+++ b/matlab/src/inversenomeq.m
@@ -44,42 +44,23 @@ end
 
 m = zeros(size(q));
 q = q(:).';    % make a row vector
-maxq = max(q);
 
-if ~all(q >= 0) || ~all(q <= 1)
-    error('Input arguments must be from the interval [0,1].')
+if ~all(q >= 0) || ~all(q < 1)
+    error('Input arguments must be from the interval [0,1).')
 end
 
-if any(q > 0.76) || any(q < 0.00001)
-    warning('WarnTests:convertTest', ...
-            'The function INVERSENOMEQ does not return \ncorrect values of M for Q < 0.00001 and Q > 0.76, because of computer precision limitation.');
+% Closed form, DLMF 20.9.1:  m = (theta2(0,q)/theta3(0,q))^4
+%   theta2(0,q) = 2*q^(1/4) * sum q^(n(n+1)),  theta3(0,q) = 1 + 2*sum q^(n^2)
+% The q^(1/4) factor is kept outside the ratio so tiny q cannot underflow.
+% This replaces the old interpolation tables, which were documented as
+% unreliable for q < 1e-5 and q > 0.76; the series is exact at every scale
+% down to m(1e-30) = 1.6e-29.
+s2 = ones(size(q));                 % sum q^(n(n+1)), n >= 0
+s3 = ones(size(q));                 % theta3 = 1 + 2*sum q^(n^2)
+for n = 1:30
+    s2 = s2 + q.^(n*(n+1));
+    s3 = s3 + 2*q.^(n^2);
 end
-
-I = find (q <= 0.4);
-J = find (q > 0.4 & q <= 0.6);
-P = find (q > 0.6);
-
-if (~isempty(I))
-    mm = 0:0.0001:1;
-    K = ellipke(mm);
-    KK = K(end:-1:1)./K;
-    m(I) = interp1(KK, mm, -1/pi*log(q(I)), 'pchip','extrap');
-end
-
-if (~isempty(J))
-    mm = 0.9996:0.0000001:1-eps;
-    %K = 1/8*(-2+2*mm-2*(-5+mm)*log(4)+(-5+mm).*log(1-mm));
-    K = 1/128*(-53+74*mm-21*mm.^2+2*(89+mm.*(-34+9*mm))*log(4)+(-89+mm.*(34-9*mm)).*log(1-mm));
-    KK = pi/2./K;
-    m(J) = interp1(KK, mm, -1/pi*log(q(J)), 'pchip','extrap');
-end
-
-if (~isempty(P))
-    mm = (1-10^8*eps):1000*eps:1-eps;
-    K = 1/128*(-53+74*mm-21*mm.^2+2*(89+mm.*(-34+9*mm))*log(4)+(-89+mm.*(34-9*mm)).*log(1-mm));
-    KK = pi/2./K;
-    m(P) = interp1(KK, mm, -1/pi*log(q(P)), 'pchip','extrap');
-    % plot(mm,K*log(q(P))+pi*pi/2,'.');
-end
+m(:) = 16*q .* (s2./s3).^4;
 
 % END FUNCTION inversenomeq()

--- a/matlab/src/weierstrassP.m
+++ b/matlab/src/weierstrassP.m
@@ -67,7 +67,10 @@ w   = z .* sqrt(e1 - e3);
 [sn, ~, ~] = ellipj(w, m);
 P   = e3 + (e1 - e3) ./ sn.^2;
 % Poles: sn -> 0 at z = 0 and at lattice points
-P(abs(sn) < eps^(1/3)) = Inf;
+% Pole only where sn vanishes exactly (z at a representable lattice
+% point): the old abs(sn) < eps^(1/3) window (~6e-6!) replaced huge
+% finite near-pole values -- P(1e-16) ~ 1e32 -- with Inf.
+P(sn == 0) = Inf;
 
 
 % -----------------------------------------------------------------------
@@ -79,7 +82,10 @@ w    = z_f .* sqrt(e1_f - e3_f);
 % ellipj sees has_gpu()=true and dispatches to gpu_ellipj automatically
 [sn, ~, ~] = ellipj(w, m);
 P    = e3_f + (e1_f - e3_f) ./ sn.^2;
-P(abs(sn) < eps^(1/3)) = Inf;
+% Pole only where sn vanishes exactly (z at a representable lattice
+% point): the old abs(sn) < eps^(1/3) window (~6e-6!) replaced huge
+% finite near-pole values -- P(1e-16) ~ 1e32 -- with Inf.
+P(sn == 0) = Inf;
 P    = reshape(P, origSize);
 
 

--- a/matlab/src/weierstrassPPrime.m
+++ b/matlab/src/weierstrassPPrime.m
@@ -67,7 +67,10 @@ w    = z .* sqrt(e1 - e3);
 scale = -2 .* (e1 - e3).^(3/2);
 dP   = scale .* cn .* dn ./ sn.^3;
 % Poles: sn -> 0 at z = 0 and at lattice points
-dP(abs(sn) < eps^(1/3)) = Inf;
+% Pole only where sn vanishes exactly (z at a representable lattice
+% point): the old abs(sn) < eps^(1/3) window (~6e-6!) replaced huge
+% finite near-pole values -- P(1e-16) ~ 1e32 -- with Inf.
+dP(sn == 0) = Inf;
 
 
 % -----------------------------------------------------------------------
@@ -79,7 +82,10 @@ w    = z_f .* sqrt(e1_f - e3_f);
 [sn, cn, dn] = ellipj(w, m);
 scale = -2 .* (e1_f - e3_f).^(3/2);
 dP   = scale .* cn .* dn ./ sn.^3;
-dP(abs(sn) < eps^(1/3)) = Inf;
+% Pole only where sn vanishes exactly (z at a representable lattice
+% point): the old abs(sn) < eps^(1/3) window (~6e-6!) replaced huge
+% finite near-pole values -- P(1e-16) ~ 1e32 -- with Inf.
+dP(sn == 0) = Inf;
 dP   = reshape(dP, origSize);
 
 

--- a/matlab/tests/testEdgeCases.m
+++ b/matlab/tests/testEdgeCases.m
@@ -500,8 +500,8 @@
 %! end
 
 % ---------------------------------------------------------------------
-% P. uniquetol_compat — the grouping map that feeds the AGM in
-%    elliptic12/ellipj.  Contract: C(ic) reconstructs A within tol,
+% P. uniquetol_compat — compatibility utility (the numerical kernels now
+%    group exact duplicates only). Contract: C(ic) reconstructs A within tol,
 %    C == A(ia) exactly, C strictly increasing, and near-duplicates
 %    (within tol) collapse to one group.  A wrong index map here would
 %    silently corrupt every m-grouped elliptic value downstream.
@@ -517,11 +517,11 @@
 %! assert(isequal(C(:), A(ia)(:)), 'C must equal A(ia) exactly');
 %! assert(all(diff(C) > 0), 'C must be strictly increasing');
 %! assert(all(diff(C) > tol * max(1, abs(C(1:end-1)))), 'groups closer than tol survived');
-%! % elliptic12 must give identical results whether m is grouped or not:
+%! % elliptic12 must preserve every distinct m rather than tolerance-group it:
 %! m_dup = [0.4, 0.4+5e-13, 0.4-5e-13, 0.7, 0.7+1e-12];
 %! [F1,E1] = elliptic12(1.1*ones(size(m_dup)), m_dup);
 %! for k = 1:numel(m_dup)
 %!     [F2,E2] = elliptic12(1.1, m_dup(k));
-%!     assert(abs(F1(k)-F2) < 5e-11 && abs(E1(k)-E2) < 5e-11, ...
+%!     assert(abs(F1(k)-F2) < 2e-13 && abs(E1(k)-E2) < 2e-13, ...
 %!         'grouped vs scalar elliptic12 disagree at k=%d', k);
 %! end

--- a/matlab/tests/testEdgeCases.m
+++ b/matlab/tests/testEdgeCases.m
@@ -525,3 +525,79 @@
 %!     assert(abs(F1(k)-F2) < 2e-13 && abs(E1(k)-E2) < 2e-13, ...
 %!         'grouped vs scalar elliptic12 disagree at k=%d', k);
 %! end
+
+% ---------------------------------------------------------------------
+% Q. Adversarial-review round (external Codex + mpmath 1.4.1, dps=40).
+%    Each block below is a counterexample that a prior version failed.
+% ---------------------------------------------------------------------
+%!test
+%! clear
+%! % Q1: negative amplitude while the COMPLETE integral has a pole (0*Inf).
+%! assert(abs(elliptic3(-1, 0.5, 1)   - (-1.7319915420235269928)) < 1e-13, 'Pi(-1|.5,1) wrong');
+%! assert(abs(elliptic3(-1, 1,   0.2) - (-1.3115010674599590753)) < 1e-13, 'Pi(-1|1,.2) wrong');
+%! assert(~isnan(elliptic3(-0.4, 1, 1)), 'Pi(-0.4|1,1) must not be NaN');
+
+%!test
+%! clear
+%! % Q2: complex F/E small-m series region (A&S path lost sqrt(eps/m) digits).
+%! assert(abs(elliptic12i(0.2i, 1e-20) - 0.2i) < 1e-15, 'F(0.2i|1e-20)');
+%! [F,E] = elliptic12i(pi/2 + 0.2i, 1e-14);
+%! assert(abs(F - (1.5707963267949005462 + 0.20000000000000101344i)) < 1e-13, 'F(pi/2+0.2i|1e-14)');
+%! assert(abs(E - (1.5707963267948926922 + 0.19999999999999898656i)) < 1e-13, 'E(pi/2+0.2i|1e-14)');
+%! [F,E] = elliptic12i(pi/2 + 0.2i, 1e-6);
+%! assert(abs(F - (1.5707967194941992113 + 0.20000010134411776594i)) < 5e-12, 'F(pi/2+0.2i|1e-6)');
+%! assert(abs(E - (1.5707959340957412894 + 0.19999989865593359446i)) < 5e-12, 'E(pi/2+0.2i|1e-6)');
+%! % both sides of the series threshold vs mpmath (dps=30)
+%! Fa = elliptic12i(1.1+0.3i, 0.99e-4);
+%! assert(abs(Fa - (1.1000153646885162+0.3000120622623928i)) < 1e-12, 'series side of crossover');
+%! Fb = elliptic12i(1.1+0.3i, 1.01e-4);
+%! assert(abs(Fb - (1.1000156750952820+0.3000123059589823i)) < 5e-12, 'decomposition side of crossover');
+
+%!test
+%! clear
+%! % Q3: Weierstrass near-origin values are huge but FINITE (DLMF 23.9.2);
+%! % only the exact lattice point is a pole.
+%! assert(abs(weierstrassP(1e-16,1,0,-1)      - 1e32)  < 1e19,  'P(1e-16) must be ~1e32');
+%! assert(abs(weierstrassPPrime(1e-16,1,0,-1) + 2e48)  < 1e36,  'Pp(1e-16) must be ~-2e48');
+%! assert(abs(weierstrassZeta(1e-16,1,0,-1)   - 1e16)  < 1e3,   'zeta(1e-16) must be ~1e16');
+%! assert(isinf(weierstrassP(0,1,0,-1)), 'P(0) must be Inf');
+
+%!test
+%! clear
+%! % Q4: inverse nome via DLMF 20.9.1 -- exact at every scale.
+%! assert(abs(inversenomeq(1e-30) - 1.6e-29) < 1e-41, 'm(1e-30) must be 1.6e-29');
+%! assert(abs(inversenomeq(1e-12) - 1.5999999999872e-11) < 1e-24, 'm(1e-12) = 16q - 128q^2');
+%! for mv = [1e-8 0.3 0.85 0.999]
+%!     assert(abs(inversenomeq(nomeq(mv)) - mv) < 1e-12*max(mv,1e-3), 'roundtrip fails at m=%g', mv);
+%! end
+
+%!test
+%! clear
+%! % Q5: Carlson scale invariance (DLMF 19.20): RF ~ lambda^(-1/2), RC same,
+%! % RD/RJ ~ lambda^(-3/2).  An absolute branch tolerance broke this.
+%! x=1; y=2; z=3; p=4;
+%! for lam = [1e-20 1e20]
+%!     assert(abs(carlsonRF(lam*x,lam*y,lam*z)     - carlsonRF(x,y,z)/sqrt(lam))       < 1e-10*abs(carlsonRF(x,y,z)/sqrt(lam)), 'RF homogeneity at %g', lam);
+%!     assert(abs(carlsonRC(lam*x,lam*y)           - carlsonRC(x,y)/sqrt(lam))         < 1e-10*abs(carlsonRC(x,y)/sqrt(lam)), 'RC homogeneity at %g', lam);
+%!     assert(abs(carlsonRD(lam*x,lam*y,lam*z)     - carlsonRD(x,y,z)/lam^1.5)         < 1e-10*abs(carlsonRD(x,y,z)/lam^1.5), 'RD homogeneity at %g', lam);
+%!     assert(abs(carlsonRJ(lam*x,lam*y,lam*z,lam*p) - carlsonRJ(x,y,z,p)/lam^1.5)     < 1e-10*abs(carlsonRJ(x,y,z,p)/lam^1.5), 'RJ homogeneity at %g', lam);
+%! end
+%! assert(abs(carlsonRC(1e-20,2e-20) - 7853981633.9744830962) < 1e-4, 'RC(1e-20,2e-20)');
+
+%!test
+%! clear
+%! % Q6: ellipticBD nondegenerate anchors (mpmath: B=(E-(1-m)K)/m, D=(K-E)/m).
+%! R = [0.2 0.8066808960371526438 0.85294270257337535705
+%!      0.7 0.88437375336868858245 1.1909893819237805614
+%!      0.999 0.99832798626015502386 3.8428045742901420065];
+%! for i = 1:rows(R)
+%!     [B,D] = ellipticBD(R(i,1));
+%!     assert(abs(B - R(i,2)) < 1e-14, 'B(%g)', R(i,1));
+%!     assert(abs(D - R(i,3)) < 1e-13, 'D(%g)', R(i,1));
+%! end
+
+%!test
+%! clear
+%! % Q7: reversed arc intervals are signed, circles included.
+%! assert(abs(arclength_ellipse(2,3,1,0.1) + arclength_ellipse(2,3,0.1,1)) < 1e-13, 'ellipse arc not odd under reversal');
+%! assert(abs(arclength_ellipse(2,2,1,0.1) - (-1.8)) < 1e-13, 'reversed circle arc must be -a*(t1-t0)');

--- a/matlab/tests/testGpu.m
+++ b/matlab/tests/testGpu.m
@@ -30,6 +30,8 @@
 %! if ~gpu_available_for_test(), disp('SKIP: no GPU'); return; end
 %! [phi, alpha] = meshgrid(linspace(0.01, pi/2, 40), linspace(0.01, pi/2, 40));
 %! u = phi(:).'; m = sin(alpha(:).').^2;
+%! u = [u, pi+0.3, 3*pi+0.7, -4*pi-0.2];
+%! m = [m, 0.2, 0.5, 0.8];
 %! [F_s, E_s, Z_s] = elliptic12(u, m);
 %! elliptic_config('gpu', true);
 %! [F_g, E_g, Z_g] = elliptic12(u, m);
@@ -43,8 +45,8 @@
 %! clear
 %! elliptic_config('gpu', false);
 %! if ~gpu_available_for_test(), disp('SKIP: no GPU'); return; end
-%! [phi, alpha, cv] = meshgrid(linspace(0, pi/2, 20), linspace(0, pi/2, 20), linspace(0, 0.9, 5));
-%! u = phi(:).'; m = sin(alpha(:).').^2; c = cv(:).';
+%! [phi, mv, cv] = meshgrid(linspace(0, 1.4, 20), linspace(0, 0.7, 20), linspace(0, 0.7, 5));
+%! u = phi(:).'; m = mv(:).'; c = cv(:).';
 %! Pi_s = elliptic3(u, m, c);
 %! elliptic_config('gpu', true);
 %! Pi_g = elliptic3(u, m, c);
@@ -58,6 +60,8 @@
 %! if ~gpu_available_for_test(), disp('SKIP: no GPU'); return; end
 %! [phi, alpha] = meshgrid(linspace(0, 10, 40), linspace(0, pi/2, 40));
 %! u = phi(:).'; m = sin(alpha(:).').^2;
+%! u = [u, 1e3+0.123, 1e6+0.123];
+%! m = [m, 0.5, 0.9];
 %! [Sn_s, Cn_s, Dn_s, Am_s] = ellipj(u, m);
 %! elliptic_config('gpu', true);
 %! [Sn_g, Cn_g, Dn_g, Am_g] = ellipj(u, m);

--- a/matlab/tests/testRegressionFollowup.m
+++ b/matlab/tests/testRegressionFollowup.m
@@ -1,0 +1,57 @@
+% Regression coverage from the post-0d09740 deep audit.
+
+%!test
+%! % m=1: period reduction must not hide the first F pole or under-count E.
+%! phi = [2, pi, 4, 10];
+%! [F, E, Z] = elliptic12(phi, ones(size(phi)));
+%! turns = floor((abs(phi) + pi/2) ./ pi);
+%! expectedE = (-1).^turns .* sin(abs(phi)) + 2.*turns;
+%! assert(all(isinf(F) & F > 0), 'F(phi|1) must diverge after crossing pi/2');
+%! assert(max(abs(E-expectedE)) < 1e-14, 'E(phi|1) period accounting failed');
+%! [Fn, En, Zn] = elliptic12(-phi, ones(size(phi)));
+%! assert(all(isinf(Fn) & Fn < 0), 'negative F(phi|1) pole sign failed');
+%! assert(max(abs(En+E)) < 1e-14 && max(abs(Zn+Z)) < 1e-14, 'm=1 parity failed');
+
+%!test
+%! % B, D and especially S retain their analytic limits for tiny m.
+%! m = [0, 1e-20, 1e-16, 1e-12, 1e-8];
+%! [B, D, S] = ellipticBD(m);
+%! assert(max(abs(B-pi/4)) < 2e-8, 'B lost its m->0 limit');
+%! assert(max(abs(D-pi/4)) < 2e-8, 'D lost its m->0 limit');
+%! assert(max(abs(S-pi/16)) < 2e-8, 'S suffered small-m cancellation');
+
+%!test
+%! % Near-pole third-kind value anchored to scipy Carlson RF/RJ.
+%! got = elliptic3(pi/2, 0.9, 0.999);
+%! expected = 149.26048203240563;
+%! assert(abs(got-expected) < 2e-12, ...
+%!     'elliptic3 near-pole error: got %.17g expected %.17g', got, expected);
+
+%!test
+%! % Large u and the closest representable m<1: mpmath 50-digit anchor.
+%! u = 1000000.123;
+%! m = 1 - eps/2;
+%! [sn, cn, dn] = ellipj(u, m);
+%! assert(abs(sn-0.9999999999999987) < 2e-14, 'large-u sn lost phase');
+%! assert(abs(cn-5.0691640447381745e-08) < 2e-14, 'large-u cn lost phase');
+%! assert(abs(dn-5.177513605688685e-08) < 2e-14, 'large-u dn cancellation');
+
+%!test
+%! % Distinct m values must never be tolerance-grouped into one data point.
+%! u = 1.56;
+%! m = [0.999, 0.999+5e-12, 0.5, 0.5+5e-12];
+%! [Fv, Ev] = elliptic12(u*ones(size(m)), m);
+%! for k = 1:numel(m)
+%!     [Fs, Es] = elliptic12(u, m(k));
+%!     assert(abs(Fv(k)-Fs) < 2e-13 && abs(Ev(k)-Es) < 2e-13, ...
+%!         'array evaluation substituted m at index %d', k);
+%! end
+
+%!test
+%! % elliptic123 must route through the repaired public implementation.
+%! phi = [0.4, 1.2, 2.0, 4.0];
+%! m = 0.4*ones(size(phi));
+%! [F123, E123] = elliptic123(phi, m);
+%! [F, E] = elliptic12(phi, m);
+%! assert(max(abs(F123-F)) < 2e-12 && max(abs(E123-E)) < 2e-12, ...
+%!     'elliptic123 retained a stale private elliptic12 implementation');

--- a/python/elliptic/applications.py
+++ b/python/elliptic/applications.py
@@ -1,7 +1,8 @@
 """Application-level helpers built on top of the core elliptic functions."""
 from __future__ import annotations
 import numpy as np
-from array_api_compat import array_namespace
+
+from ._xputils import get_xp
 from .elliptic12 import elliptic12
 
 
@@ -43,19 +44,38 @@ def arclength_ellipse(a, b, theta0=0.0, theta1=None):
     if theta1 is None:
         theta1 = 2.0 * np.pi
 
-    a = float(a); b = float(b)
-    theta0 = float(theta0); theta1 = float(theta1)
+    xp = get_xp(a, b, theta0, theta1)
+    a = xp.asarray(a, dtype=xp.float64)
+    b = xp.asarray(b, dtype=xp.float64)
+    theta0 = xp.asarray(theta0, dtype=xp.float64)
+    theta1 = xp.asarray(theta1, dtype=xp.float64)
+    a, b, theta0, theta1 = xp.broadcast_arrays(a, b, theta0, theta1)
 
-    if a == b:
-        return a * abs(theta1 - theta0)
+    # Give ordinary NumPy callers an explicit domain error.  Traced backends
+    # cannot branch on array values, so invalid elements are marked NaN below.
+    if xp is np and (np.any(a <= 0.0) or np.any(b <= 0.0)):
+        raise ValueError("ellipse semi-axes must be strictly positive")
 
-    if b > a:
-        m = 1.0 - (a / b) ** 2
-        _, E1, _ = elliptic12(np.asarray(theta1), np.asarray(m))
-        _, E0, _ = elliptic12(np.asarray(theta0), np.asarray(m))
-        return float(b * (float(E1) - float(E0)))
-    else:  # a > b
-        m = 1.0 - (b / a) ** 2
-        _, E1, _ = elliptic12(np.asarray(np.pi / 2.0 - theta1), np.asarray(m))
-        _, E0, _ = elliptic12(np.asarray(np.pi / 2.0 - theta0), np.asarray(m))
-        return float(a * (float(E0) - float(E1)))
+    valid = (a > 0.0) & (b > 0.0)
+    a_safe = xp.where(valid, a, xp.ones_like(a))
+    b_safe = xp.where(valid, b, xp.ones_like(b))
+
+    # Evaluate both orientations elementwise.  The old scalar ``float`` casts
+    # rejected arrays and JAX tracers even though the rest of the public API is
+    # backend-native.
+    m_b = 1.0 - (a_safe / b_safe) ** 2
+    m_a = 1.0 - (b_safe / a_safe) ** 2
+
+    _, E1_b, _ = elliptic12(theta1, xp.where(b > a, m_b, xp.zeros_like(m_b)))
+    _, E0_b, _ = elliptic12(theta0, xp.where(b > a, m_b, xp.zeros_like(m_b)))
+
+    comp1 = np.pi / 2.0 - theta1
+    comp0 = np.pi / 2.0 - theta0
+    _, E1_a, _ = elliptic12(comp1, xp.where(a > b, m_a, xp.zeros_like(m_a)))
+    _, E0_a, _ = elliptic12(comp0, xp.where(a > b, m_a, xp.zeros_like(m_a)))
+
+    arc_b = b_safe * (E1_b - E0_b)
+    arc_a = a_safe * (E0_a - E1_a)
+    arc_circle = a_safe * xp.abs(theta1 - theta0)
+    arc = xp.where(b > a, arc_b, xp.where(a > b, arc_a, arc_circle))
+    return xp.where(valid, arc, xp.full_like(arc, np.nan))

--- a/python/elliptic/applications.py
+++ b/python/elliptic/applications.py
@@ -76,6 +76,8 @@ def arclength_ellipse(a, b, theta0=0.0, theta1=None):
 
     arc_b = b_safe * (E1_b - E0_b)
     arc_a = a_safe * (E0_a - E1_a)
-    arc_circle = a_safe * xp.abs(theta1 - theta0)
+    # Signed, like the ellipse branches: reversed intervals negate
+    # (the old abs() here made circles disagree with every non-circle).
+    arc_circle = a_safe * (theta1 - theta0)
     arc = xp.where(b > a, arc_b, xp.where(a > b, arc_a, arc_circle))
     return xp.where(valid, arc, xp.full_like(arc, np.nan))

--- a/python/elliptic/carlson.py
+++ b/python/elliptic/carlson.py
@@ -31,26 +31,30 @@ def carlsonRC(x, y):
 
 
 def _rc_xp(xp, x, y):
-    EPS = 1e-300
     diff = y - x
-    TOL = 1e-14
+    # Branch selection must be RELATIVE: R_C is homogeneous of degree -1/2
+    # (DLMF 19.20.3), and an absolute |y-x| < 1e-14 window sent every
+    # small-scale input down the degenerate x==y branch -- RC(1e-20, 2e-20)
+    # returned 1/sqrt(x), a 27% error.
+    scale = xp.maximum(xp.abs(x), xp.abs(y))
+    tol = 1e-14 * scale
 
     # safe arguments for each branch (avoid div-by-zero when not selected)
-    x_safe   = xp.where(x > EPS, x, xp.full_like(x, 1.0))
-    yd_safe  = xp.where(diff > EPS, diff, xp.full_like(diff, 1.0))
-    yd_safe2 = xp.where(-diff > EPS, -diff, xp.full_like(diff, 1.0))
-    y_safe   = xp.where(y > EPS, y, xp.full_like(y, 1.0))
+    x_safe   = xp.where(x > 0, x, xp.full_like(x, 1.0))
+    yd_safe  = xp.where(diff > 0, diff, xp.full_like(diff, 1.0))
+    yd_safe2 = xp.where(-diff > 0, -diff, xp.full_like(diff, 1.0))
+    y_safe   = xp.where(y > 0, y, xp.full_like(y, 1.0))
 
     rc_gt  = xp.arctan(xp.sqrt(xp.clip(diff / x_safe, 0.0, None))) / xp.sqrt(yd_safe)
-    lt_active = (diff < -TOL) & (y > EPS) & (x > EPS)
+    lt_active = (diff < -tol) & (y > 0) & (x > 0)
     lt_ratio = xp.where(lt_active, -diff / x_safe, xp.full_like(diff, 0.5))
     rc_lt  = xp.arctanh(xp.sqrt(xp.clip(lt_ratio, 0.0, None))) / xp.sqrt(yd_safe2)
     rc_eq  = 1.0 / xp.sqrt(x_safe)
     rc_x0  = (math.pi * 0.5) / xp.sqrt(y_safe)
 
-    out = xp.where(diff > TOL, rc_gt, xp.where(diff < -TOL, rc_lt, rc_eq))
-    out = xp.where(x < EPS, rc_x0, out)
-    out = xp.where(y < EPS, xp.full_like(out, math.inf), out)
+    out = xp.where(diff > tol, rc_gt, xp.where(diff < -tol, rc_lt, rc_eq))
+    out = xp.where(x == 0, rc_x0, out)
+    out = xp.where(y == 0, xp.full_like(out, math.inf), out)
     return out
 
 

--- a/python/elliptic/carlson.py
+++ b/python/elliptic/carlson.py
@@ -33,6 +33,7 @@ def carlsonRC(x, y):
 def _rc_xp(xp, x, y):
     EPS = 1e-300
     diff = y - x
+    TOL = 1e-14
 
     # safe arguments for each branch (avoid div-by-zero when not selected)
     x_safe   = xp.where(x > EPS, x, xp.full_like(x, 1.0))
@@ -41,11 +42,12 @@ def _rc_xp(xp, x, y):
     y_safe   = xp.where(y > EPS, y, xp.full_like(y, 1.0))
 
     rc_gt  = xp.arctan(xp.sqrt(xp.clip(diff / x_safe, 0.0, None))) / xp.sqrt(yd_safe)
-    rc_lt  = xp.arctanh(xp.sqrt(xp.clip(-diff / x_safe, 0.0, None))) / xp.sqrt(yd_safe2)
+    lt_active = (diff < -TOL) & (y > EPS) & (x > EPS)
+    lt_ratio = xp.where(lt_active, -diff / x_safe, xp.full_like(diff, 0.5))
+    rc_lt  = xp.arctanh(xp.sqrt(xp.clip(lt_ratio, 0.0, None))) / xp.sqrt(yd_safe2)
     rc_eq  = 1.0 / xp.sqrt(x_safe)
     rc_x0  = (math.pi * 0.5) / xp.sqrt(y_safe)
 
-    TOL = 1e-14
     out = xp.where(diff > TOL, rc_gt, xp.where(diff < -TOL, rc_lt, rc_eq))
     out = xp.where(x < EPS, rc_x0, out)
     out = xp.where(y < EPS, xp.full_like(out, math.inf), out)
@@ -156,8 +158,7 @@ def carlsonRJ(x, y, z, p):
     p = xp.asarray(p, dtype=xp.float64)
     x, y, z, p = xp.broadcast_arrays(x, y, z, p)
 
-    import numpy as _np
-    if _np.any(_np.asarray(p) <= 0.0):
+    if xp is np and np.any(p <= 0.0):
         raise ValueError(
             "carlsonRJ: p must be > 0. For p < 0 the integral is a Cauchy "
             "principal value (DLMF 19.20.14); use the transformation to "

--- a/python/elliptic/complex_elliptic.py
+++ b/python/elliptic/complex_elliptic.py
@@ -98,10 +98,25 @@ def elliptic12i(u, m):
     K_m, E_m, _ = _elliptic12_xp(xp, xp.full_like(m_f, np.pi * 0.5), m_f)
     Zi   = Ei - (E_m / K_m) * Fi
 
-    # Exact elementary limit at m=0.
-    Fi = xp.where(m_f == 0.0, u_f, Fi)
-    Ei = xp.where(m_f == 0.0, u_f, Ei)
-    Zi = xp.where(m_f == 0.0, xp.zeros_like(Fi), Zi)
+    # Small-m Maclaurin series (through m^2).  The A&S 17.4.11 decomposition
+    # loses ~sqrt(eps/m) digits as m -> 0 (0.2 absolute at m = 1e-16); the
+    # series is exact there and covers m = 0 itself:
+    #   F = u + m(u/4 - sin2u/8) + m^2(9u/64 - 3sin2u/32 + 3sin4u/256) + O(m^3)
+    #   E = u - m(u/4 - sin2u/8) - m^2(3u/64 -  sin2u/32 +  sin4u/256) + O(m^3)
+    # Valid while |m sin^2 u| is small: switch on m*max(1, e^(2|psi|)) < 1e-4,
+    # where the crossover error is ~2e-12 (measured against 40-digit mpmath).
+    m_eff = m_f * xp.maximum(xp.ones_like(m_f), xp.exp(2.0 * xp.abs(psi)))
+    small = m_eff < 1e-4
+    s2 = xp.sin(2.0 * u_f)
+    s4 = xp.sin(4.0 * u_f)
+    F_ser = (u_f + m_f * (u_f / 4.0 - s2 / 8.0)
+             + m_f**2 * (9.0 * u_f / 64.0 - 3.0 * s2 / 32.0 + 3.0 * s4 / 256.0))
+    E_ser = (u_f - m_f * (u_f / 4.0 - s2 / 8.0)
+             - m_f**2 * (3.0 * u_f / 64.0 - s2 / 32.0 + s4 / 256.0))
+    Z_ser = E_ser - (E_m / K_m) * F_ser
+    Fi = xp.where(small, F_ser, Fi)
+    Ei = xp.where(small, E_ser, Ei)
+    Zi = xp.where(small, Z_ser, Zi)
     return Fi, Ei, Zi
 
 

--- a/python/elliptic/complex_elliptic.py
+++ b/python/elliptic/complex_elliptic.py
@@ -8,10 +8,10 @@ argument into two real-valued calls, then combine analytically.
 """
 from __future__ import annotations
 import numpy as np
-from array_api_compat import array_namespace
 
-from .elliptic12 import _elliptic12_numpy
-from .ellipj import _ellipj_numpy
+from ._xputils import get_xp
+from .elliptic12 import _elliptic12_xp
+from .ellipj import _ellipj_xp
 
 
 def elliptic12i(u, m):
@@ -28,76 +28,81 @@ def elliptic12i(u, m):
     -------
     Fi, Ei, Zi : complex arrays
     """
-    u = np.asarray(u, dtype=np.complex128)
-    m = np.asarray(m, dtype=np.float64)
-    xp = array_namespace(np.real(u), m)
+    xp = get_xp(u, m)
+    u = xp.asarray(u, dtype=xp.complex128)
+    m = xp.asarray(m, dtype=xp.float64)
+    u_f, m_f = xp.broadcast_arrays(u, m)
 
-    u_bc, m_bc = np.broadcast_arrays(u, m)
-    orig_shape = u_bc.shape
-    u_f = u_bc.ravel()
-    m_f = m_bc.ravel().astype(np.float64)
-
-    if np.any(m_f < 0) or np.any(m_f > 1):
+    if xp is np and np.any((m_f < 0.0) | (m_f > 1.0)):
         raise ValueError("m must be in [0, 1]")
 
-    phi = np.real(u_f)
-    psi = np.imag(u_f)
+    phi = xp.real(u_f)
+    psi = xp.imag(u_f)
 
     # Avoid cot(phi) singularity at phi = 0
-    phi_s = np.where(np.abs(phi) < np.finfo(float).eps, np.finfo(float).eps, phi)
+    eps = np.finfo(np.float64).eps
+    phi_s = xp.where(xp.abs(phi) < eps, xp.full_like(phi, eps), phi)
 
     # Roots of   X² - b*X - c = 0   (A&S 17.4.11)
-    cot2   = (np.cos(phi_s) / np.sin(phi_s))**2
-    sinh2  = np.sinh(psi)**2
-    csc2   = 1.0 / np.sin(phi_s)**2
+    cot2   = (xp.cos(phi_s) / xp.sin(phi_s))**2
+    sinh2  = xp.sinh(psi)**2
+    csc2   = 1.0 / xp.sin(phi_s)**2
     b      = -(cot2 + m_f * sinh2 * csc2 - 1.0 + m_f)
     c      = -(1.0 - m_f) * cot2
 
-    disc  = np.sqrt(np.maximum(b**2 / 4.0 - c, 0.0))
+    disc = xp.sqrt(xp.maximum(b**2 / 4.0 - c, xp.zeros_like(c)))
 
     # c <= 0, so the roots straddle zero and -b/2 + disc is the non-negative
     # one.  Near phi = pi/2 that form cancels catastrophically (both terms
     # ~ |b|/2 while the root ~ 0), so use the equal -c/(b/2 + disc) when b > 0.
-    den   = np.where(b > 0, b / 2.0 + disc, 1.0)     # b > 0 => den >= b/2 > 0
-    X     = np.where(b > 0, -c / den, -b / 2.0 + disc)
-    ratio = np.where(b > 0, (1.0 - m_f) / den,       # == tan(phi)² · cot(lam)²
-                     (-b / 2.0 + disc) / cot2)
+    den = xp.where(b > 0, b / 2.0 + disc, xp.ones_like(b))
+    X = xp.where(b > 0, -c / den, -b / 2.0 + disc)
+    ratio = xp.where(
+        b > 0,
+        (1.0 - m_f) / den,
+        (-b / 2.0 + disc) / cot2,
+    )
 
-    lam  = np.arctan(1.0 / np.sqrt(np.maximum(X, 0.0) + 1e-300))
+    lam = xp.arctan(1.0 / xp.sqrt(xp.maximum(X, xp.zeros_like(X)) + 1e-300))
     # tan(mu)² = (tan(phi)²·cot(lam)² - 1)/m, taken from *ratio* rather than
     # from lam: at phi = pi/2 the root X underflows, lam rounds to exactly
     # pi/2 and cot(lam) loses every digit of it, collapsing Im to zero.
-    mu   = np.arctan(np.sqrt(np.maximum((ratio - 1.0) / m_f, 0.0)))
+    m_calc = xp.where(m_f == 0.0, xp.ones_like(m_f), m_f)
+    mu = xp.arctan(
+        xp.sqrt(xp.maximum((ratio - 1.0) / m_calc, xp.zeros_like(ratio)))
+    )
 
     # Account for periodicity
-    lam = (-1.0)**np.floor(phi / np.pi * 2) * lam + np.pi * np.ceil(phi / np.pi - 0.5 + 1e-14)
-    mu  = np.sign(psi) * np.real(mu)
+    lam = (
+        (-1.0) ** xp.floor(phi / np.pi * 2.0) * lam
+        + np.pi * xp.ceil(phi / np.pi - 0.5 + 1e-14)
+    )
+    mu = xp.sign(psi) * xp.real(mu)
 
-    F1, E1, _ = _elliptic12_numpy(lam, m_f, np.finfo(np.float64).eps)
-    F2, E2, _ = _elliptic12_numpy(mu,  1.0 - m_f, np.finfo(np.float64).eps)
+    F1, E1, _ = _elliptic12_xp(xp, lam, m_f)
+    F2, E2, _ = _elliptic12_xp(xp, mu, 1.0 - m_f)
 
     Fi = F1 + 1j * F2
 
     # E addition formula (A&S 17.4.16)
-    sl = np.sin(lam);  cl = np.cos(lam)
-    sm = np.sin(mu);   cm = np.cos(mu)
+    sl = xp.sin(lam);  cl = xp.cos(lam)
+    sm = xp.sin(mu);   cm = xp.cos(mu)
     d2l = 1.0 - m_f * sl**2
     d2m = 1.0 - (1.0 - m_f) * sm**2
     den = cm**2 + m_f * sl**2 * sm**2
-    b1  = m_f * sl * cl * sm**2 * np.sqrt(d2l)
-    b2  = sm * cm * d2l * np.sqrt(d2m)
+    b1  = m_f * sl * cl * sm**2 * xp.sqrt(d2l)
+    b2  = sm * cm * d2l * xp.sqrt(d2m)
     Ei  = (b1 + 1j * b2) / den + E1 + 1j * (-E2 + F2)
 
     # Z = E - (E_complete / K) * F
-    from scipy.special import ellipk, ellipe as _ellipe
-    K_m  = ellipk(m_f)
-    E_m  = _ellipe(m_f)
+    K_m, E_m, _ = _elliptic12_xp(xp, xp.full_like(m_f, np.pi * 0.5), m_f)
     Zi   = Ei - (E_m / K_m) * Fi
 
-    Fi = Fi.reshape(orig_shape)
-    Ei = Ei.reshape(orig_shape)
-    Zi = Zi.reshape(orig_shape)
-    return xp.asarray(Fi), xp.asarray(Ei), xp.asarray(Zi)
+    # Exact elementary limit at m=0.
+    Fi = xp.where(m_f == 0.0, u_f, Fi)
+    Ei = xp.where(m_f == 0.0, u_f, Ei)
+    Zi = xp.where(m_f == 0.0, xp.zeros_like(Fi), Zi)
+    return Fi, Ei, Zi
 
 
 def ellipji(u, m):
@@ -117,23 +122,19 @@ def ellipji(u, m):
     -------
     sn, cn, dn : complex arrays
     """
-    u = np.asarray(u, dtype=np.complex128)
-    m = np.asarray(m, dtype=np.float64)
-    xp = array_namespace(np.real(u), m)
+    xp = get_xp(u, m)
+    u_f = xp.asarray(u, dtype=xp.complex128)
+    m_f = xp.asarray(m, dtype=xp.float64)
+    u_f, m_f = xp.broadcast_arrays(u_f, m_f)
 
-    u_bc, m_bc = np.broadcast_arrays(u, m)
-    orig_shape = u_bc.shape
-    u_f = u_bc.ravel()
-    m_f = m_bc.ravel().astype(np.float64)
-
-    if np.any(m_f < 0) or np.any(m_f > 1):
+    if xp is np and np.any((m_f < 0.0) | (m_f > 1.0)):
         raise ValueError("m must be in [0, 1]")
 
-    phi = np.real(u_f)
-    psi = np.imag(u_f)
+    phi = xp.real(u_f)
+    psi = xp.imag(u_f)
 
-    s,  c,  d,  _ = _ellipj_numpy(phi, m_f)
-    s1, c1, d1, _ = _ellipj_numpy(psi, 1.0 - m_f)
+    s,  c,  d,  _ = _ellipj_xp(xp, phi, m_f)
+    s1, c1, d1, _ = _ellipj_xp(xp, psi, 1.0 - m_f)
 
     delta = c1**2 + m_f * s**2 * s1**2
 
@@ -141,7 +142,4 @@ def ellipji(u, m):
     cni = (c * c1 - 1j * s * d * s1 * d1) / delta
     dni = (d * c1 * d1 - 1j * m_f * s * c * s1) / delta
 
-    sni = sni.reshape(orig_shape)
-    cni = cni.reshape(orig_shape)
-    dni = dni.reshape(orig_shape)
-    return xp.asarray(sni), xp.asarray(cni), xp.asarray(dni)
+    return sni, cni, dni

--- a/python/elliptic/ellipj.py
+++ b/python/elliptic/ellipj.py
@@ -33,8 +33,12 @@ def ellipj(u, m):
 
 
 def _ellipj_xp(xp, u, m):
-    # Clamp m away from exact 0/1 so sqrt is defined; edge cases handled below.
-    m_safe = xp.clip(m, 1e-15, 1.0 - 1e-15)
+    # Keep every representable interior parameter unchanged.  The old global
+    # clip to [1e-15, 1-1e-15] silently changed valid inputs near both
+    # endpoints (most visibly m=nextafter(1, 0)).  Exact endpoints use a
+    # harmless interior placeholder here and are replaced below.
+    interior = (m > 0.0) & (m < 1.0)
+    m_safe = xp.where(interior, m, xp.full_like(m, 0.5))
 
     a = xp.ones_like(m_safe)
     b = xp.sqrt(1.0 - m_safe)
@@ -47,30 +51,48 @@ def _ellipj_xp(xp, u, m):
         b = xp.sqrt(a * b)
         a = ab_sum * 0.5
 
-    # Starting amplitude:  phi_N = 2^N * a_N * u
-    phin = (2.0 ** _AGM_ITERS) * a * u
+    # Reduce u before multiplying by 2^N.  Without this, the large argument
+    # enters the Landen recursion directly and loses phase bits; near m=1 the
+    # error can become O(1) after only a few dozen periods.
+    K = np.pi / (2.0 * a)
+    period = xp.floor((u + K) / (2.0 * K))
+    u_reduced = u - 2.0 * period * K
+
+    # Starting amplitude on [-K, K]: phi_N = 2^N * a_N * u_reduced
+    phin = (2.0 ** _AGM_ITERS) * a * u_reduced
 
     # Descending Landen back-substitution (all elements, fixed 25 steps)
     for i in range(_AGM_ITERS - 1, -1, -1):
         arg  = xp.clip(ratios[i] * xp.sin(phin), -1.0, 1.0)
         phin = 0.5 * (xp.arcsin(arg) + phin)
 
-    sn_g = xp.sin(phin)
-    cn_g = xp.cos(phin)
-    dn_g = xp.sqrt(xp.clip(1.0 - m_safe * sn_g * sn_g, 0.0, None))
+    period_mod2 = period - 2.0 * xp.floor(period * 0.5)
+    quasi_sign = 1.0 - 2.0 * period_mod2
+    sn_g = quasi_sign * xp.sin(phin)
+    cn_g = quasi_sign * xp.cos(phin)
+    # The cn form avoids subtracting two nearly equal numbers when m and
+    # |sn| are both close to one.
+    dn_g = xp.sqrt(xp.clip((1.0 - m_safe) + m_safe * cn_g * cn_g, 0.0, None))
+    am_g = phin + period * np.pi
+
+    # Stable sech avoids overflow in cosh for large non-m=1 elements.  Array
+    # backends evaluate both sides of where, so a nominally unselected cosh
+    # still emitted warnings/overflowed during ordinary calls.
+    exp_neg = xp.exp(-xp.abs(u))
+    sech_u = 2.0 * exp_neg / (1.0 + exp_neg * exp_neg)
 
     # Blend exact m=0 and m=1 results
     sn = xp.where(m == 0.0, xp.sin(u),
          xp.where(m == 1.0, xp.tanh(u), sn_g))
     cn = xp.where(m == 0.0, xp.cos(u),
-         xp.where(m == 1.0, 1.0 / xp.cosh(u), cn_g))
+         xp.where(m == 1.0, sech_u, cn_g))
     dn = xp.where(m == 0.0, xp.ones_like(u),
-         xp.where(m == 1.0, 1.0 / xp.cosh(u), dn_g))
+         xp.where(m == 1.0, sech_u, dn_g))
     # am is the *continuous* amplitude from the Landen recursion, not
     # arcsin(sn): the latter folds it into [-pi/2, pi/2] and so loses the
     # period count (DLMF 22.16.1: am(u + 2K) = am(u) + pi).
     am = xp.where(m == 0.0, u,
-         xp.where(m == 1.0, xp.arcsin(xp.clip(xp.tanh(u), -1.0, 1.0)), phin))
+         xp.where(m == 1.0, xp.arcsin(xp.clip(xp.tanh(u), -1.0, 1.0)), am_g))
     return sn, cn, dn, am
 
 

--- a/python/elliptic/ellipj.py
+++ b/python/elliptic/ellipj.py
@@ -1,5 +1,10 @@
 """Jacobi elliptic functions sn, cn, dn, am — native on any array backend.
 
+Accuracy limit for large arguments: the phase is reduced modulo 2K in
+double precision, so the residual carries an absolute uncertainty ~|u|*eps.
+Full precision holds for |u| up to ~1e12; by |u| ~ 1e16 the phase is lost
+entirely (a bound shared by every double implementation, scipy included).
+
 Algorithm: Arithmetic-Geometric Mean + descending Landen back-substitution
 (Abramowitz & Stegun §16.4).  Fixed 25 AGM iterations, no per-element
 convergence tracking → fully data-parallel on CUDA / JAX.

--- a/python/elliptic/elliptic12.py
+++ b/python/elliptic/elliptic12.py
@@ -78,16 +78,23 @@ def _elliptic12_xp(xp, u, m):
     E = xp.where(m == 0.0, u, E)
     Z = xp.where(m == 0.0, xp.zeros_like(Z), Z)
 
-    # m == 1: F = log(tan(π/4 + u_r/2)), E via sin, Z = sin(u_r)
-    F_m1 = xp.log(xp.tan(math.pi / 4 + u_r * 0.5))
-    um1  = xp.abs(u_r)
-    Nf   = xp.floor((um1 + math.pi * 0.5) / math.pi)
+    # m == 1: F has its first non-integrable pole at |u|=π/2.  Period
+    # reduction must not hide that crossing (the old code returned F=0 at
+    # u=π and also under-counted E beyond the first quadrant).
+    um1 = xp.abs(u)
+    Nf = xp.floor((um1 + math.pi * 0.5) / math.pi)
     sgn  = xp.where(u >= 0.0, xp.ones_like(u), -xp.ones_like(u))
     E_m1 = ((-1.0) ** Nf * xp.sin(um1) + 2.0 * Nf) * sgn
-    Z_m1 = xp.sin(u_r)           # (-1)^Nf * sin(u), Nf=0 for |u_r|<π/2
+    Z_m1 = xp.sin(u_r)
 
-    near_pole_m1 = xp.abs(u_r) >= math.pi * 0.5 - 1e-14
-    F_m1 = xp.where(near_pole_m1, xp.full_like(F_m1, math.inf) * sgn, F_m1)
+    crossed_pole_m1 = um1 >= math.pi * 0.5
+    u_m1_safe = xp.where(crossed_pole_m1, xp.zeros_like(u), u)
+    F_m1_finite = xp.log(xp.tan(math.pi * 0.25 + 0.5 * u_m1_safe))
+    F_m1 = xp.where(
+        crossed_pole_m1,
+        xp.full_like(F_m1_finite, math.inf) * sgn,
+        F_m1_finite,
+    )
     F = xp.where(m == 1.0, F_m1, F)
     E = xp.where(m == 1.0, E_m1, E)
     Z = xp.where(m == 1.0, Z_m1, Z)

--- a/python/elliptic/elliptic12.py
+++ b/python/elliptic/elliptic12.py
@@ -4,7 +4,7 @@
     E(phi, m) = integral_0^phi  sqrt(1 - m sin^2 t)      dt
     Z(phi, m) = E(phi, m) - E(m)/K(m) * F(phi, m)   [Jacobi Zeta]
 
-Algorithm: Carlson symmetric forms (DLMF 19.25.5-6):
+Algorithm: Carlson symmetric forms (DLMF 19.25.5 for F, 19.25.9 for E):
     F = sin(phi) * RF(cos^2, 1-m sin^2, 1)
     E = F - m * sin^3(phi)/3 * RD(cos^2, 1-m sin^2, 1)
     Z = E - E(m)/K(m) * F   where K=RF(0,1-m,1), E(m)=K - m/3*RD(0,1-m,1)

--- a/python/elliptic/elliptic3.py
+++ b/python/elliptic/elliptic3.py
@@ -2,7 +2,7 @@
 
     Pi(u, m, n) = integral_0^u  1 / ((1 - n sin^2 t) sqrt(1 - m sin^2 t))  dt
 
-Algorithm: Carlson symmetric forms (DLMF 19.25.1). Pure array-namespace
+Algorithm: Carlson symmetric forms (DLMF 19.25.14). Pure array-namespace
 operations run natively on NumPy, PyTorch CUDA, and JAX.
 """
 from __future__ import annotations

--- a/python/elliptic/elliptic3.py
+++ b/python/elliptic/elliptic3.py
@@ -2,31 +2,16 @@
 
     Pi(u, m, n) = integral_0^u  1 / ((1 - n sin^2 t) sqrt(1 - m sin^2 t))  dt
 
-Algorithm: 10-point Gauss-Legendre quadrature. Pure array-namespace ops —
-runs natively on NumPy, PyTorch CUDA, and JAX without any np.asarray conversion.
+Algorithm: Carlson symmetric forms (DLMF 19.25.1). Pure array-namespace
+operations run natively on NumPy, PyTorch CUDA, and JAX.
 """
 from __future__ import annotations
 
 import math
+import numpy as np
 
 from ._xputils import get_xp
-
-# 10-point Gauss-Legendre nodes and weights on [0, 1] as plain Python floats
-# (so they broadcast correctly against any backend tensor)
-_GL_T = [
-    0.9931285991850949, 0.9639719272779138,
-    0.9122344282513259, 0.8391169718222188,
-    0.7463319064601508, 0.6360536807265150,
-    0.5108670019508271, 0.3737060887154195,
-    0.2277858511416451, 0.07652652113349734,
-]
-_GL_W = [
-    0.01761400713915212, 0.04060142980038694,
-    0.06267204833410907, 0.08327674157670475,
-    0.10193011981724040, 0.11819453196151840,
-    0.13168863844917660, 0.14209610931838200,
-    0.14917298647260370, 0.15275338713072580,
-]
+from .carlson import _rf_xp, _rj_xp
 
 
 def elliptic3(u, m, n):
@@ -34,12 +19,13 @@ def elliptic3(u, m, n):
 
     Parameters
     ----------
-    u : array_like   Phase in radians, 0 <= u <= pi/2.
+    u : array_like   Phase in radians.
     m : array_like   Parameter, 0 <= m <= 1.
     n : array_like   Characteristic, n <= 1. For n > 1 the integral is a
                      Cauchy principal value (circular case, DLMF 19.7.3)
-                     which 10-point Gauss–Legendre cannot resolve; this
-                     function raises ValueError in that regime.
+                     which this real-valued implementation does not resolve;
+                     NumPy calls raise ValueError when the integration path
+                     crosses that pole.
 
     Returns
     -------
@@ -51,18 +37,20 @@ def elliptic3(u, m, n):
     n = xp.asarray(n, dtype=xp.float64)
     u, m, n = xp.broadcast_arrays(u, m, n)
 
-    import numpy as _np
-    n_np = _np.asarray(n)
-    u_np = _np.asarray(u)
-    if _np.any(n_np > 1.0):
+    # Eager NumPy calls can provide a precise domain error.  Traced backends
+    # cannot branch on array values; their invalid elements naturally become
+    # non-finite through the Carlson expression instead.
+    if xp is np and np.any(n > 1.0):
+        n_np = np.asarray(n)
+        u_np = np.asarray(u)
         # Check whether the singularity sin²θ = 1/n lies in [0, u]
-        with _np.errstate(invalid='ignore', divide='ignore'):
-            sing = _np.where(n_np > 1.0, _np.arcsin(_np.sqrt(1.0 / n_np)), _np.inf)
-        if _np.any((n_np > 1.0) & (u_np >= sing)):
+        with np.errstate(invalid="ignore", divide="ignore"):
+            sing = np.where(n_np > 1.0, np.arcsin(np.sqrt(1.0 / n_np)), np.inf)
+        if np.any((n_np > 1.0) & (np.abs(u_np) >= sing)):
             raise ValueError(
                 "elliptic3: n > 1 with phase beyond the pole at arcsin(1/sqrt(n)) "
-                "is a Cauchy principal-value integral (DLMF 19.7.3); not supported "
-                "by 10-point Gauss–Legendre. Use a transformation (DLMF 19.7.4) "
+                "is a Cauchy principal-value integral (DLMF 19.7.3); not supported. "
+                "Use a transformation (DLMF 19.7.4) "
                 "or compute via Carlson R_J with complex arguments."
             )
 
@@ -71,50 +59,42 @@ def elliptic3(u, m, n):
     #   Pi(-u)      = -Pi(u)
     #   Pi(u+k*pi)  =  Pi(u) + 2k*Pi(pi/2)
     #   Pi(pi-u)    =  2*Pi(pi/2) - Pi(u)
-    # The 10-point Gauss-Legendre rule below is only accurate on [0, pi/2];
-    # larger phases used to be evaluated directly and were silently wrong
-    # (~1e-6 at u = 6).
     sign_u = xp.where(u < 0, -xp.ones_like(u), xp.ones_like(u))
     ua     = xp.abs(u)
     k_per  = xp.floor(ua / math.pi)
     r      = ua - k_per * math.pi                       # in [0, pi)
     refl   = r > math.pi * 0.5
     u_red  = xp.where(refl, math.pi - r, r)             # in [0, pi/2]
-    reduced = xp.any(k_per > 0) or xp.any(refl) or xp.any(u < 0)
+    s = xp.sin(u_red)
+    c = xp.cos(u_red)
+    s2 = s * s
+    d2 = 1.0 - m * s2
+    p = 1.0 - n * s2
+    one = xp.ones_like(s)
 
-    u = u_red
-    half_u = u * 0.5
-    P = xp.zeros_like(u)
-    for ti, wi in zip(_GL_T, _GL_W):
-        c0  = half_u * ti
-        tp  = half_u + c0
-        tm  = half_u - c0
-        s2p = xp.sin(tp) ** 2
-        s2m = xp.sin(tm) ** 2
-        P = P + wi * (
-            1.0 / ((1.0 - n * s2p) * xp.sqrt(xp.clip(1.0 - m * s2p, 0.0, None))) +
-            1.0 / ((1.0 - n * s2m) * xp.sqrt(xp.clip(1.0 - m * s2m, 0.0, None)))
-        )
-    Pi = half_u * P
+    RF = _rf_xp(xp, c * c, d2, one)
+    RJ = _rj_xp(xp, c * c, d2, one, p)
+    Pi_red = s * RF + n * s * s2 * RJ / 3.0
+    Pi_red = xp.where(s == 0.0, xp.zeros_like(Pi_red), Pi_red)
 
-    if reduced:
-        # Complete integral Pi(pi/2|m,n) by the same rule, then undo the
-        # reduction:  Pi(|u|) = 2k*Pcpl + refl*2*Pcpl ± Pi(u_red),  * sign(u)
-        qtr = math.pi * 0.25
-        Pc = xp.zeros_like(u)
-        for ti, wi in zip(_GL_T, _GL_W):
-            tp  = qtr + qtr * ti
-            tm  = qtr - qtr * ti
-            s2p = xp.sin(tp) ** 2
-            s2m = xp.sin(tm) ** 2
-            Pc = Pc + wi * (
-                1.0 / ((1.0 - n * s2p) * xp.sqrt(xp.clip(1.0 - m * s2p, 0.0, None))) +
-                1.0 / ((1.0 - n * s2m) * xp.sqrt(xp.clip(1.0 - m * s2m, 0.0, None)))
-            )
-        Pc = qtr * Pc
-        Pi = sign_u * (2.0 * k_per * Pc + xp.where(refl, 2.0 * Pc, xp.zeros_like(Pc))
-                       + xp.where(refl, -Pi, Pi))
+    # Complete Π is needed to restore reflected/full periods.  Replace
+    # singular complete parameters while evaluating the eager expression so
+    # unselected branches stay finite on autodiff backends.
+    complete_singular = (m == 1.0) | (n >= 1.0)
+    m_complete = xp.where(complete_singular, xp.zeros_like(m), m)
+    n_complete = xp.where(complete_singular, xp.zeros_like(n), n)
+    zero = xp.zeros_like(s)
+    RF_complete = _rf_xp(xp, zero, 1.0 - m_complete, one)
+    RJ_complete = _rj_xp(xp, zero, 1.0 - m_complete, one, 1.0 - n_complete)
+    Pi_complete = RF_complete + n_complete * RJ_complete / 3.0
 
-    # u == pi/2 and (m == 1 or n == 1) → inf
-    inf_mask = ((u == math.pi * 0.5) & (m == 1.0)) | ((u == math.pi * 0.5) & (n == 1.0))
-    return xp.where(inf_mask, xp.full_like(Pi, math.inf), Pi)
+    Pi_abs = (
+        2.0 * k_per * Pi_complete
+        + xp.where(refl, 2.0 * Pi_complete - Pi_red, Pi_red)
+    )
+    Pi = sign_u * Pi_abs
+
+    # At m=1 or n=1 the path diverges once it reaches the first π/2 pole.
+    crosses_endpoint_pole = complete_singular & (ua >= math.pi * 0.5)
+    signed_inf = sign_u * xp.full_like(Pi, math.inf)
+    return xp.where(crosses_endpoint_pole, signed_inf, Pi)

--- a/python/elliptic/ellipticBD.py
+++ b/python/elliptic/ellipticBD.py
@@ -14,7 +14,7 @@ import math
 import numpy as np
 
 from ._xputils import get_xp
-from .elliptic12 import _elliptic12_xp
+from .carlson import _rf_xp, _rd_xp
 
 
 def ellipticBD(m):
@@ -34,17 +34,24 @@ def ellipticBD(m):
 
 
 def _bd_xp(xp, m):
-    phi = xp.full_like(m, math.pi * 0.5)
-    K, E, _ = _elliptic12_xp(xp, phi, m)
-
-    # D = (K - E) / m,  limit at m=0: π/4
-    D = xp.where(m == 0.0,
-                 xp.full_like(m, math.pi * 0.25),
-                 (K - E) / xp.where(m == 0.0, xp.ones_like(m), m))
+    zero = xp.zeros_like(m)
+    one = xp.ones_like(m)
+    K = _rf_xp(xp, zero, 1.0 - m, one)
+    D = _rd_xp(xp, zero, 1.0 - m, one) / 3.0
     B = K - D
-    S = xp.where(m == 0.0,
-                 xp.full_like(m, math.pi / 16.0),
-                 (D - B) / xp.where(m == 0.0, xp.ones_like(m), m))
+
+    # S=(D-B)/m is catastrophically cancelling near m=0.  Evaluate its
+    # convergent binomial/integral series there:
+    #   1/sqrt(1-m sin²t) = Σ C_k m^k sin^(2k)t.
+    S_series = xp.zeros_like(m)
+    for k in range(1, 9):
+        ck = math.comb(2 * k, k) / (4.0 ** k)
+        ik = math.pi * math.comb(2 * k, k) / (2.0 * 4.0 ** k)
+        ik1 = math.pi * math.comb(2 * k + 2, k + 1) / (2.0 * 4.0 ** (k + 1))
+        S_series = S_series + ck * (2.0 * ik1 - ik) * m ** (k - 1)
+    m_safe = xp.where(m == 0.0, xp.ones_like(m), m)
+    S_direct = (D - B) / m_safe
+    S = xp.where(xp.abs(m) < 1e-2, S_series, S_direct)
     return B, D, S
 
 

--- a/python/elliptic/inverse.py
+++ b/python/elliptic/inverse.py
@@ -1,13 +1,16 @@
 """Inverse incomplete elliptic integral of the second kind."""
 from __future__ import annotations
+import math
 import numpy as np
+from ._xputils import get_xp
+from .elliptic12 import _elliptic12_xp
 
 
 def inverselliptic2(E_val, m, tol=1e-12):
     """Inverse of the incomplete elliptic integral of the second kind.
 
-    Solves  E(phi | m) = E_val  for phi using period reduction, Boyd (2012)
-    initialisation, and a Newton while-loop (issue #12: converges to *tol*).
+    Solves E(phi | m) = E_val using period reduction and fixed-step Newton
+    refinement against the library's own Carlson implementation.
 
     Period identity:  E(phi + pi | m) = E(phi | m) + 2*E(m)
     Symmetry:         E(pi - phi | m) = 2*E(m) - E(phi | m)
@@ -20,55 +23,43 @@ def inverselliptic2(E_val, m, tol=1e-12):
 
     Returns
     -------
-    phi : ndarray   Amplitude in radians such that E(phi | m) ≈ E_val.
+    phi : array   Amplitude in radians such that E(phi | m) ≈ E_val.
     """
-    from scipy.special import ellipe, ellipeinc
+    xp = get_xp(E_val, m)
+    E_val = xp.asarray(E_val, dtype=xp.float64)
+    m = xp.asarray(m, dtype=xp.float64)
+    E_val, m = xp.broadcast_arrays(E_val, m)
 
-    E_val = np.asarray(E_val, dtype=np.float64)
-    m     = np.asarray(m,     dtype=np.float64)
-
-    orig_shape = np.broadcast_shapes(E_val.shape, m.shape)
-    E_flat = np.broadcast_to(E_val, orig_shape).ravel().copy()
-    m_flat = np.broadcast_to(m,     orig_shape).ravel().copy()
-
-    if np.any(m_flat < 0) or np.any(m_flat > 1):
+    if xp is np and np.any((m < 0.0) | (m > 1.0)):
         raise ValueError("m must be in [0, 1]")
-    m_flat = np.where(m_flat < np.finfo(float).eps, 0.0, m_flat)
 
     # Complete integral E(m); each phi-period of π contributes 2*E1 to E.
-    E1 = ellipe(m_flat)
-    two_E1 = 2.0 * np.where(E1 > 0, E1, 1.0)
+    half_pi = xp.full_like(m, math.pi * 0.5)
+    _, E1, _ = _elliptic12_xp(xp, half_pi, m)
+    two_E1 = 2.0 * E1
 
     # Step 1 — strip full periods:  phi = phi_base + k*pi
-    k     = np.floor(E_flat / two_E1)
-    z_red = E_flat - k * two_E1          # in [0, 2*E1)
+    k = xp.floor(E_val / two_E1)
+    z_red = E_val - k * two_E1          # in [0, 2*E1)
 
     # Step 2 — fold second half-period using E(pi-phi|m) = 2E1 - E(phi|m)
-    over   = z_red > E1
-    z_red2 = np.where(over, two_E1 - z_red, z_red)   # in [0, E1]
+    over = z_red > E1
+    z_red2 = xp.where(over, two_E1 - z_red, z_red)   # in [0, E1]
 
-    # Boyd (2012) empirical initialisation for phi in [0, pi/2]
-    mu    = 1.0 - m_flat
-    zeta  = 1.0 - z_red2 / np.where(E1 > 0, E1, 1.0)
-    r     = np.sqrt(zeta**2 + mu**2)
-    theta = np.arctan2(mu, z_red2 + 1e-300)
-    phi   = np.pi / 2.0 + np.sqrt(r) * (theta - np.pi / 2.0)
-    phi   = np.clip(phi, 0.0, np.pi / 2.0)
+    # Monotone linear seed in [0, pi/2].  Fixed iteration count keeps the
+    # routine JIT-safe; converged elements simply receive zero-sized updates.
+    phi = xp.clip((z_red2 / E1) * (math.pi * 0.5), 0.0, math.pi * 0.5)
 
-    # Newton while-loop until converged (issue #12: fixed 4 iters insufficient)
-    for _ in range(200):
-        E_cur = ellipeinc(phi, m_flat)
-        res   = E_cur - z_red2
-        if np.max(np.abs(res)) < tol:
-            break
-        denom = np.sqrt(np.maximum(1.0 - m_flat * np.sin(phi)**2, 0.0))
-        phi   = phi - res / np.where(denom < 1e-15, 1e-15, denom)
-        phi   = np.clip(phi, 0.0, np.pi / 2.0)
+    for _ in range(24):
+        _, E_cur, _ = _elliptic12_xp(xp, phi, m)
+        res = E_cur - z_red2
+        denom = xp.sqrt(xp.clip(1.0 - m * xp.sin(phi) ** 2, 0.0, None))
+        safe_denom = xp.where(denom > tol, denom, xp.ones_like(denom))
+        step = xp.where(xp.abs(res) > tol, res / safe_denom, xp.zeros_like(res))
+        phi = xp.clip(phi - step, 0.0, math.pi * 0.5)
 
     # Step 3 — undo fold: phi_in_period = pi - phi (if over), else phi
-    phi = np.where(over, np.pi - phi, phi)   # in [0, pi)
+    phi = xp.where(over, math.pi - phi, phi)   # in [0, pi)
 
     # Step 4 — undo period strips: each strip adds pi to phi
-    phi = phi + k * np.pi
-
-    return phi.reshape(orig_shape) if orig_shape else phi.squeeze()
+    return phi + k * math.pi

--- a/python/elliptic/jacobi_edj.py
+++ b/python/elliptic/jacobi_edj.py
@@ -10,7 +10,7 @@ Relations:
 """
 from __future__ import annotations
 
-import numpy as np
+from ._xputils import get_xp
 from .ellipj import ellipj
 from .ellipticBDJ import ellipticBDJ
 
@@ -32,14 +32,20 @@ def jacobiEDJ(u, m, n=None):
     Eu, Du : arrays
     Ju : array or None
     """
-    u_arr = np.asarray(u, dtype=np.float64)
-    m_arr = np.asarray(m, dtype=np.float64)
-    u_arr, m_arr = np.broadcast_arrays(u_arr, m_arr)
+    args = (u, m, n) if n is not None else (u, m)
+    xp = get_xp(*args)
+    u_arr = xp.asarray(u, dtype=xp.float64)
+    m_arr = xp.asarray(m, dtype=xp.float64)
+    if n is None:
+        u_arr, m_arr = xp.broadcast_arrays(u_arr, m_arr)
+    else:
+        n = xp.asarray(n, dtype=xp.float64)
+        u_arr, m_arr, n = xp.broadcast_arrays(u_arr, m_arr, n)
 
     _, _, _, phi = ellipj(u_arr, m_arr)
     B, D, J = ellipticBDJ(phi, m_arr, n)
 
     Du = D
-    Eu = u_arr - m_arr * np.asarray(D)
+    Eu = u_arr - m_arr * D
     Ju = J
     return Eu, Du, Ju

--- a/python/elliptic/nome.py
+++ b/python/elliptic/nome.py
@@ -43,8 +43,6 @@ def inversenomeq(q):
     m : array
         Parameter m = m(q) in [0, 1).
     """
-    import warnings
-
     xp = get_xp(q)
     q = xp.asarray(q, dtype=xp.float64)
 
@@ -54,28 +52,24 @@ def inversenomeq(q):
     if xp is np:
         if np.any((q < 0.0) | (q >= 1.0)):
             raise ValueError("q must be in [0, 1)")
-        if np.any(q >= q_max):
+        if np.any(q > q_max):
             raise ValueError(
-                f"inversenomeq: q must be < {q_max:.15f} in double precision "
+                f"inversenomeq: q must be <= {q_max:.15f} in double precision "
                 "(the essential singularity of m(q) at q=1 cannot be resolved in f64)"
             )
-        if np.any(q > 0.76):
-            warnings.warn(
-                "inversenomeq: accuracy degrades for q > 0.76 (near m=1 singularity)",
-                RuntimeWarning,
-                stacklevel=2,
-            )
 
-    valid = (q >= 0.0) & (q < q_max)
+    # Closed form, DLMF 20.9.1:  m = (theta2(0,q) / theta3(0,q))^4.
+    # Exact at every scale -- the previous 64-step bisection in m had an
+    # absolute resolution floor of 2^-64, so m(1e-30) came back 2.7e-20
+    # instead of 1.6e-29 (nine orders of magnitude off).
+    #   theta2(0,q) = 2 q^(1/4) sum q^(n(n+1)),  theta3(0,q) = 1 + 2 sum q^(n^2)
+    # The q^(1/4) factor is kept outside the ratio so tiny q cannot underflow.
+    valid = (q >= 0.0) & (q <= q_max)
     q_safe = xp.where(valid, q, xp.zeros_like(q))
-    lo = xp.zeros_like(q_safe)
-    hi = xp.full_like(q_safe, m_hi_scalar)
-    for _ in range(64):
-        mid = 0.5 * (lo + hi)
-        q_mid = _q_from_m_xp(xp, mid)
-        lower = q_mid < q_safe
-        lo = xp.where(lower, mid, lo)
-        hi = xp.where(lower, hi, mid)
-    result = 0.5 * (lo + hi)
-    result = xp.where(q == 0.0, xp.zeros_like(result), result)
+    s2 = xp.ones_like(q_safe)                   # sum q^(n(n+1)), n >= 0
+    s3 = xp.ones_like(q_safe)                   # theta3 = 1 + 2 sum q^(n^2)
+    for n in range(1, 31):
+        s2 = s2 + q_safe ** (n * (n + 1))
+        s3 = s3 + 2.0 * q_safe ** (n * n)
+    result = 16.0 * q_safe * (s2 / s3) ** 4
     return xp.where(valid, result, xp.full_like(result, math.nan))

--- a/python/elliptic/nome.py
+++ b/python/elliptic/nome.py
@@ -1,7 +1,9 @@
 """Nome q(m) and its inverse m(q)."""
 from __future__ import annotations
+import math
 import numpy as np
-from array_api_compat import array_namespace
+from ._xputils import get_xp
+from .theta import _q_from_m_xp
 
 
 def nomeq(m):
@@ -17,23 +19,19 @@ def nomeq(m):
     q : array
         Nome in [0, 1).
     """
-    from scipy.special import ellipk
-    m = np.asarray(m, dtype=np.float64)
-    xp = array_namespace(m)
-    m_np = np.asarray(m).ravel()
-    K  = ellipk(m_np)
-    Kp = ellipk(1.0 - m_np)
-    q  = np.exp(-np.pi * Kp / K)
-    q  = q.reshape(np.asarray(m).shape)
-    return xp.asarray(q)
+    xp = get_xp(m)
+    m = xp.asarray(m, dtype=xp.float64)
+    q = _q_from_m_xp(xp, m)
+    return xp.where(m == 1.0, xp.ones_like(q), q)
 
 
 def inversenomeq(q):
     """Inverse nome: parameter m from nome q.
 
-    Uses ``scipy.optimize.brentq`` to invert ``nomeq``. In double precision the
-    representable range is roughly q ∈ [0, 0.779]; beyond this, m(q) exceeds
-    1 - 2⁻⁵³ and cannot be represented.
+    Uses a fixed-iteration bisection against the library's own Carlson-based
+    ``nomeq`` implementation. In double precision the representable range is
+    roughly q ∈ [0, 0.779]; beyond this, m(q) exceeds 1 - 2⁻⁵³ and cannot be
+    represented.
 
     Parameters
     ----------
@@ -46,38 +44,38 @@ def inversenomeq(q):
         Parameter m = m(q) in [0, 1).
     """
     import warnings
-    from scipy.optimize import brentq
-    from scipy.special import ellipk
 
-    q = np.asarray(q, dtype=np.float64)
-    xp = array_namespace(q)
-    q_flat = np.asarray(q).ravel()
+    xp = get_xp(q)
+    q = xp.asarray(q, dtype=xp.float64)
 
-    if np.any(q_flat < 0) or np.any(q_flat >= 1):
-        raise ValueError("q must be in [0, 1)")
+    m_hi_scalar = np.nextafter(1.0, 0.0)
+    q_max = float(_q_from_m_xp(np, np.asarray(m_hi_scalar)))
 
-    m_hi  = np.nextafter(1.0, 0.0)        # largest f64 strictly < 1
-    q_max = float(np.exp(-np.pi * ellipk(1.0 - m_hi) / ellipk(m_hi)))
-    if np.any(q_flat >= q_max):
-        raise ValueError(
-            f"inversenomeq: q must be < {q_max:.15f} in double precision "
-            "(the essential singularity of m(q) at q=1 cannot be resolved in f64)"
-        )
-    if np.any(q_flat > 0.76):
-        warnings.warn("inversenomeq: accuracy degrades for q > 0.76 (near m=1 singularity)",
-                      RuntimeWarning, stacklevel=2)
+    if xp is np:
+        if np.any((q < 0.0) | (q >= 1.0)):
+            raise ValueError("q must be in [0, 1)")
+        if np.any(q >= q_max):
+            raise ValueError(
+                f"inversenomeq: q must be < {q_max:.15f} in double precision "
+                "(the essential singularity of m(q) at q=1 cannot be resolved in f64)"
+            )
+        if np.any(q > 0.76):
+            warnings.warn(
+                "inversenomeq: accuracy degrades for q > 0.76 (near m=1 singularity)",
+                RuntimeWarning,
+                stacklevel=2,
+            )
 
-    def _nomeq_scalar(m_val):
-        K  = float(ellipk(m_val))
-        Kp = float(ellipk(1.0 - m_val))
-        return float(np.exp(-np.pi * Kp / K))
-
-    m_out = np.empty_like(q_flat)
-    for i, qi in enumerate(q_flat):
-        if qi == 0.0:
-            m_out[i] = 0.0
-        else:
-            m_out[i] = brentq(lambda m: _nomeq_scalar(m) - qi, 0.0, m_hi, xtol=1e-14)
-
-    m_out = m_out.reshape(np.asarray(q).shape)
-    return xp.asarray(m_out)
+    valid = (q >= 0.0) & (q < q_max)
+    q_safe = xp.where(valid, q, xp.zeros_like(q))
+    lo = xp.zeros_like(q_safe)
+    hi = xp.full_like(q_safe, m_hi_scalar)
+    for _ in range(64):
+        mid = 0.5 * (lo + hi)
+        q_mid = _q_from_m_xp(xp, mid)
+        lower = q_mid < q_safe
+        lo = xp.where(lower, mid, lo)
+        hi = xp.where(lower, hi, mid)
+    result = 0.5 * (lo + hi)
+    result = xp.where(q == 0.0, xp.zeros_like(result), result)
+    return xp.where(valid, result, xp.full_like(result, math.nan))

--- a/python/elliptic/theta.py
+++ b/python/elliptic/theta.py
@@ -14,82 +14,86 @@ and maps to the standard θⱼ(v, q(m)).
 """
 from __future__ import annotations
 import math
-import numpy as np
-from array_api_compat import array_namespace
+from ._xputils import get_xp
+from .carlson import _rf_xp
 
 _N_TERMS = 30   # sufficient for |q| ≤ 0.8 (m ≤ ~0.9997)
 
 
-def _q_from_m(m_np: np.ndarray) -> np.ndarray:
-    """Nome q(m) — uses scipy K; kept internal to avoid circular import."""
-    from scipy.special import ellipk
-    K  = ellipk(m_np)
-    Kp = ellipk(1.0 - m_np)
-    return np.exp(-np.pi * Kp / K)
+def _q_from_m_xp(xp, m):
+    """Backend-native nome q(m), with invalid/singular inputs masked."""
+    valid = (m >= 0.0) & (m < 1.0)
+    m_safe = xp.where(valid, m, xp.full_like(m, 0.5))
+    zero = xp.zeros_like(m_safe)
+    one = xp.ones_like(m_safe)
+    K = _rf_xp(xp, zero, 1.0 - m_safe, one)
+    Kp = _rf_xp(xp, zero, m_safe, one)
+    q = xp.exp(-math.pi * Kp / K)
+    return xp.where(valid, q, xp.full_like(q, math.nan))
 
 
 # -----------------------------------------------------------------------
 # Low-level series (flat 1-D numpy, v in radians, q scalar or array)
 # -----------------------------------------------------------------------
 
-def _th1(v: np.ndarray, q: np.ndarray) -> np.ndarray:
+def _th1(xp, v, q):
     """θ₁(v, q)."""
-    s = np.zeros_like(v)
+    s = xp.zeros_like(v)
     for n in range(_N_TERMS):
-        s += (-1)**n * q**((n + 0.5)**2) * np.sin((2*n + 1) * v)
+        s = s + (-1)**n * q**((n + 0.5)**2) * xp.sin((2*n + 1) * v)
     return 2.0 * s
 
 
-def _th2(v: np.ndarray, q: np.ndarray) -> np.ndarray:
+def _th2(xp, v, q):
     """θ₂(v, q)."""
-    s = np.zeros_like(v)
+    s = xp.zeros_like(v)
     for n in range(_N_TERMS):
-        s += q**((n + 0.5)**2) * np.cos((2*n + 1) * v)
+        s = s + q**((n + 0.5)**2) * xp.cos((2*n + 1) * v)
     return 2.0 * s
 
 
-def _th3(v: np.ndarray, q: np.ndarray) -> np.ndarray:
+def _th3(xp, v, q):
     """θ₃(v, q)."""
-    s = np.ones_like(v)
+    s = xp.ones_like(v)
     for n in range(1, _N_TERMS + 1):
-        s += 2.0 * q**(n**2) * np.cos(2*n * v)
+        s = s + 2.0 * q**(n**2) * xp.cos(2*n * v)
     return s
 
 
-def _th4(v: np.ndarray, q: np.ndarray) -> np.ndarray:
+def _th4(xp, v, q):
     """θ₄(v, q)."""
-    s = np.ones_like(v)
+    s = xp.ones_like(v)
     for n in range(1, _N_TERMS + 1):
-        s += 2.0 * (-1)**n * q**(n**2) * np.cos(2*n * v)
+        s = s + 2.0 * (-1)**n * q**(n**2) * xp.cos(2*n * v)
     return s
 
 
 # Derivatives dθⱼ/dv
-def _dth1(v: np.ndarray, q: np.ndarray) -> np.ndarray:
-    s = np.zeros_like(v)
+def _dth1(xp, v, q):
+    s = xp.zeros_like(v)
     for n in range(_N_TERMS):
-        s += (-1)**n * (2*n+1) * q**((n + 0.5)**2) * np.cos((2*n + 1) * v)
+        s = s + (-1)**n * (2*n+1) * q**((n + 0.5)**2) * xp.cos((2*n + 1) * v)
     return 2.0 * s
 
 
-def _dth2(v: np.ndarray, q: np.ndarray) -> np.ndarray:
-    s = np.zeros_like(v)
+def _dth2(xp, v, q):
+    s = xp.zeros_like(v)
     for n in range(_N_TERMS):
-        s += -(2*n+1) * q**((n + 0.5)**2) * np.sin((2*n + 1) * v)
+        s = s - (2*n+1) * q**((n + 0.5)**2) * xp.sin((2*n + 1) * v)
     return 2.0 * s
 
 
-def _dth3(v: np.ndarray, q: np.ndarray) -> np.ndarray:
-    s = np.zeros_like(v)
+def _dth3(xp, v, q):
+    s = xp.zeros_like(v)
     for n in range(1, _N_TERMS + 1):
-        s += -2.0 * 2*n * q**(n**2) * np.sin(2*n * v)
+        s = s - 4.0 * n * q**(n**2) * xp.sin(2*n * v)
     return s
 
 
-def _dth4(v: np.ndarray, q: np.ndarray) -> np.ndarray:
-    s = np.zeros_like(v)
+def _dth4(xp, v, q):
+    s = xp.zeros_like(v)
     for n in range(1, _N_TERMS + 1):
-        s += 2.0 * (-1)**n * (-2*n) * q**(n**2) * np.sin(2*n * v)
+        s = s - 4.0 * n * (-1)**n * q**(n**2) * xp.sin(2*n * v)
     return s
 
 
@@ -119,42 +123,20 @@ def jacobiThetaEta(u, m):
     Th, H : arrays
         Jacobi theta and eta values.
     """
-    from scipy.special import ellipk
-
-    u = np.asarray(u, dtype=np.float64)
-    m = np.asarray(m, dtype=np.float64)
-    xp = array_namespace(u, m)
+    xp = get_xp(u, m)
+    u = xp.asarray(u, dtype=xp.float64)
+    m = xp.asarray(m, dtype=xp.float64)
     u, m = xp.broadcast_arrays(u, m)
-    orig_shape = np.asarray(u).shape
-
-    u_np = np.asarray(u).ravel()
-    m_np = np.asarray(m).ravel()
-
-    Th = np.ones_like(u_np)
-    H  = np.zeros_like(u_np)
-
-    # m = 1: undefined
-    mask1 = m_np >= 1.0 - 1e-14
-    Th[mask1] = np.nan
-    H[mask1]  = np.nan
-
-    # m = 0: Th = 1, H = 0
-    mask0 = m_np < 1e-14
-    # already set by np.ones / np.zeros
-
-    maskN = ~mask0 & ~mask1
-    if np.any(maskN):
-        u_g = u_np[maskN]
-        m_g = m_np[maskN]
-        K_g = ellipk(m_g)
-        q_g = _q_from_m(m_g)
-        v_g = np.pi * u_g / (2.0 * K_g)       # normalised angle argument
-        Th[maskN] = _th4(v_g, q_g)
-        H[maskN]  = _th1(v_g, q_g)
-
-    Th = Th.reshape(orig_shape)
-    H  = H.reshape(orig_shape)
-    return xp.asarray(Th), xp.asarray(H)
+    valid = (m >= 0.0) & (m < 1.0)
+    m_safe = xp.where(valid, m, xp.full_like(m, 0.5))
+    zero = xp.zeros_like(m_safe)
+    K = _rf_xp(xp, zero, 1.0 - m_safe, xp.ones_like(m_safe))
+    q = _q_from_m_xp(xp, m)
+    v = math.pi * u / (2.0 * K)
+    Th = _th4(xp, v, q)
+    H = _th1(xp, v, q)
+    nan = xp.full_like(Th, math.nan)
+    return xp.where(valid, Th, nan), xp.where(valid, H, nan)
 
 
 def theta(j, v, m):
@@ -180,34 +162,12 @@ def theta(j, v, m):
     if j not in (1, 2, 3, 4):
         raise ValueError("j must be 1, 2, 3, or 4")
 
-    v = np.asarray(v, dtype=np.float64)
-    m = np.asarray(m, dtype=np.float64)
-    xp = array_namespace(v, m)
+    xp = get_xp(v, m)
+    v = xp.asarray(v, dtype=xp.float64)
+    m = xp.asarray(m, dtype=xp.float64)
     v, m = xp.broadcast_arrays(v, m)
-    orig_shape = np.asarray(v).shape
-
-    v_np = np.asarray(v).ravel()
-    m_np = np.asarray(m).ravel()
-
-    Th = np.zeros_like(v_np)
-    maskN = (m_np >= 1e-14) & (m_np < 1.0 - 1e-14)
-
-    if np.any(maskN):
-        q_g  = _q_from_m(m_np[maskN])
-        Th[maskN] = _TH_FNS[j](v_np[maskN], q_g)
-
-    # special cases
-    mask0 = m_np < 1e-14
-    if np.any(mask0):
-        if j == 1:   Th[mask0] = np.sin(v_np[mask0])  # θ₁(v,0) = sin v (leading term)
-        elif j == 2: Th[mask0] = 0.0                   # q→0 all terms vanish except trivially 0
-        elif j == 3: Th[mask0] = 1.0
-        elif j == 4: Th[mask0] = 1.0
-
-    mask1 = m_np >= 1.0 - 1e-14
-    Th[mask1] = np.nan
-
-    return xp.asarray(Th.reshape(orig_shape))
+    q = _q_from_m_xp(xp, m)
+    return _TH_FNS[j](xp, v, q)
 
 
 def theta_prime(j, v, m):
@@ -227,24 +187,9 @@ def theta_prime(j, v, m):
     if j not in (1, 2, 3, 4):
         raise ValueError("j must be 1, 2, 3, or 4")
 
-    v = np.asarray(v, dtype=np.float64)
-    m = np.asarray(m, dtype=np.float64)
-    xp = array_namespace(v, m)
+    xp = get_xp(v, m)
+    v = xp.asarray(v, dtype=xp.float64)
+    m = xp.asarray(m, dtype=xp.float64)
     v, m = xp.broadcast_arrays(v, m)
-    orig_shape = np.asarray(v).shape
-
-    v_np = np.asarray(v).ravel()
-    m_np = np.asarray(m).ravel()
-
-    th_np  = np.zeros_like(v_np)
-    thp_np = np.zeros_like(v_np)
-
-    maskN = (m_np >= 1e-14) & (m_np < 1.0 - 1e-14)
-    if np.any(maskN):
-        q_g = _q_from_m(m_np[maskN])
-        th_np[maskN]  = _TH_FNS[j](v_np[maskN], q_g)
-        thp_np[maskN] = _DTH_FNS[j](v_np[maskN], q_g)
-
-    th  = th_np.reshape(orig_shape)
-    thp = thp_np.reshape(orig_shape)
-    return xp.asarray(th), xp.asarray(thp)
+    q = _q_from_m_xp(xp, m)
+    return _TH_FNS[j](xp, v, q), _DTH_FNS[j](xp, v, q)

--- a/python/elliptic/weierstrass.py
+++ b/python/elliptic/weierstrass.py
@@ -11,8 +11,19 @@ from __future__ import annotations
 import math
 import numpy as np
 from ._xputils import get_xp
+from .carlson import _rf_xp
+
+
+def _reject_complex_inputs(*values):
+    for value in values:
+        dtype = getattr(value, "dtype", None)
+        if dtype is not None and "complex" in str(dtype).lower():
+            raise ValueError("Weierstrass functions currently support real inputs only")
+        if dtype is None and isinstance(value, complex):
+            raise ValueError("Weierstrass functions currently support real inputs only")
 
 def _broadcast4(z, e1, e2, e3):
+    _reject_complex_inputs(z, e1, e2, e3)
     xp = get_xp(z, e1, e2, e3)
     z  = xp.asarray(z,  dtype=xp.float64)
     e1 = xp.asarray(e1, dtype=xp.float64)
@@ -35,10 +46,18 @@ def weierstrassP(z, e1, e2, e3):
 def _weierP_xp(xp, z, e1, e2, e3):
     from .ellipj import _ellipj_xp
     m  = (e2 - e3) / (e1 - e3)
-    w  = z * xp.sqrt(e1 - e3)
+    scale = xp.sqrt(e1 - e3)
+    K = _rf_xp(xp, xp.zeros_like(m), 1.0 - m, xp.ones_like(m))
+    omega1 = K / scale
+    period = xp.round(z / (2.0 * omega1))
+    z_reduced = z - 2.0 * period * omega1
+    w = z_reduced * scale
     sn, _, _, _ = _ellipj_xp(xp, w, m)
     sn2 = sn * sn
-    pole = xp.abs(sn) < 1e-10
+    pole_tol = 8.0 * np.finfo(np.float64).eps * xp.maximum(
+        xp.ones_like(z), xp.abs(z)
+    )
+    pole = xp.abs(z_reduced) <= pole_tol
     P = e3 + (e1 - e3) / xp.where(pole, xp.ones_like(sn2), sn2)
     return xp.where(pole, xp.full_like(P, math.inf), P)
 
@@ -56,14 +75,11 @@ def _weierP_numpy(z, e1, e2, e3):
 
 def weierstrassZeta(z, e1, e2, e3):
     """Weierstrass zeta function (NOT Riemann zeta)."""
-    _, z, e1, e2, e3 = _broadcast4(z, e1, e2, e3)
-    orig_shape = z.shape
-    Z = _weierZ_numpy(np.asarray(z).ravel(), np.asarray(e1).ravel(),
-                      np.asarray(e2).ravel(), np.asarray(e3).ravel())
-    return np.asarray(Z.reshape(orig_shape))
+    xp, z, e1, e2, e3 = _broadcast4(z, e1, e2, e3)
+    return _weierZ_xp(xp, z, e1, e2, e3)
 
 
-def _lattice_theta_numpy(z, e1, e2, e3):
+def _lattice_theta_xp(xp, z, e1, e2, e3):
     """omega1, eta1 and the theta1 series values needed by zeta/sigma.
 
     Closed theta forms (DLMF 23.6.8/9/13): no quadrature.  Returns
@@ -71,41 +87,48 @@ def _lattice_theta_numpy(z, e1, e2, e3):
     dropped from every series -- only ratios are used downstream, except
     th1/th1p0 where both drop the same factor.
     """
-    from .elliptic12 import _elliptic12_xp
     m_param = (e2 - e3) / (e1 - e3)
-    phi_half = np.full_like(m_param, math.pi / 2)
-    K,  _, _ = _elliptic12_xp(np, phi_half, m_param)
-    Kp, _, _ = _elliptic12_xp(np, phi_half, 1.0 - m_param)
-    omega1 = K / np.sqrt(e1 - e3)
-    q = np.exp(-math.pi * Kp / K)
+    zero = xp.zeros_like(m_param)
+    one = xp.ones_like(m_param)
+    K = _rf_xp(xp, zero, 1.0 - m_param, one)
+    Kp = _rf_xp(xp, zero, m_param, one)
+    omega1 = K / xp.sqrt(e1 - e3)
+    q = xp.exp(-math.pi * Kp / K)
     v = math.pi * z / (2.0 * omega1)
 
-    qmax = float(np.max(q)) if q.size else 0.0
-    nT = min(30, max(2, math.ceil(math.sqrt(abs(math.log(np.finfo(float).eps)
-                                                / math.log(qmax)))))) if qmax > 0 else 1
-
-    th1 = np.zeros_like(v); th1p = np.zeros_like(v)
-    th1p0 = np.zeros_like(v); th1ppp0 = np.zeros_like(v)
-    for n in range(nT + 1):
+    th1 = xp.zeros_like(v)
+    th1p = xp.zeros_like(v)
+    th1p0 = xp.zeros_like(v)
+    th1ppp0 = xp.zeros_like(v)
+    for n in range(31):
         qq = (-1.0) ** n * q ** ((n + 0.5) ** 2)
         k = 2 * n + 1
-        th1     += qq * np.sin(k * v)
-        th1p    += qq * k * np.cos(k * v)
-        th1p0   += qq * k
-        th1ppp0 -= qq * k ** 3
+        th1 = th1 + qq * xp.sin(k * v)
+        th1p = th1p + qq * k * xp.cos(k * v)
+        th1p0 = th1p0 + qq * k
+        th1ppp0 = th1ppp0 - qq * k ** 3
     eta1 = -math.pi ** 2 / (12.0 * omega1) * th1ppp0 / th1p0
     return omega1, eta1, th1, th1p, th1p0
 
 
-def _weierZ_numpy(z, e1, e2, e3):
+def _weierZ_xp(xp, z, e1, e2, e3):
     # zeta(z) = eta1*z/omega1 + pi/(2*omega1) * theta1'(v)/theta1(v)  [DLMF 23.6.13]
     # Quasi-periodicity zeta(z + 2k*omega1) = zeta(z) + 2k*eta1 is carried
     # exactly by the formula; no period reduction needed.
-    omega1, eta1, th1, th1p, _ = _lattice_theta_numpy(z, e1, e2, e3)
-    with np.errstate(divide='ignore', invalid='ignore'):
-        Z = eta1 * z / omega1 + math.pi / (2.0 * omega1) * th1p / th1
-    Z[th1 == 0.0] = np.inf          # lattice points z = 2k*omega1
-    return Z
+    omega1, eta1, th1, th1p, _ = _lattice_theta_xp(xp, z, e1, e2, e3)
+    period = xp.round(z / (2.0 * omega1))
+    z_reduced = z - 2.0 * period * omega1
+    pole_tol = 8.0 * np.finfo(np.float64).eps * xp.maximum(
+        xp.ones_like(z), xp.abs(z)
+    )
+    pole = xp.abs(z_reduced) <= pole_tol
+    ratio = th1p / xp.where(pole, xp.ones_like(th1), th1)
+    Z = eta1 * z / omega1 + math.pi / (2.0 * omega1) * ratio
+    return xp.where(pole, xp.full_like(Z, math.inf), Z)
+
+
+def _weierZ_numpy(z, e1, e2, e3):
+    return _weierZ_xp(np, z, e1, e2, e3)
 
 
 # ---------------------------------------------------------------------------
@@ -114,20 +137,28 @@ def _weierZ_numpy(z, e1, e2, e3):
 
 def weierstrassSigma(z, e1, e2, e3):
     """Weierstrass sigma function (entire, odd, sigma'(z)/sigma(z) = zeta(z))."""
-    _, z, e1, e2, e3 = _broadcast4(z, e1, e2, e3)
-    orig_shape = z.shape
-    S = _weierS_numpy(np.asarray(z).ravel(), np.asarray(e1).ravel(),
-                      np.asarray(e2).ravel(), np.asarray(e3).ravel())
-    return np.asarray(S.reshape(orig_shape))
+    xp, z, e1, e2, e3 = _broadcast4(z, e1, e2, e3)
+    return _weierS_xp(xp, z, e1, e2, e3)
 
 
-def _weierS_numpy(z, e1, e2, e3):
+def _weierS_xp(xp, z, e1, e2, e3):
     # sigma(z) = 2*omega1/pi * exp(eta1*z^2/(2*omega1)) * theta1(v)/theta1'(0)
     # [DLMF 23.6.9].  Entire function: every lattice zero and sign change
     # comes out of theta1 itself.  The previous form integrated log(sigma)
     # through the zeta pole at 2*omega1 and was wrong beyond it.
-    omega1, eta1, th1, _, th1p0 = _lattice_theta_numpy(z, e1, e2, e3)
-    return 2.0 * omega1 / math.pi * np.exp(eta1 * z * z / (2.0 * omega1)) * th1 / th1p0
+    omega1, eta1, th1, _, th1p0 = _lattice_theta_xp(xp, z, e1, e2, e3)
+    return (
+        2.0
+        * omega1
+        / math.pi
+        * xp.exp(eta1 * z * z / (2.0 * omega1))
+        * th1
+        / th1p0
+    )
+
+
+def _weierS_numpy(z, e1, e2, e3):
+    return _weierS_xp(np, z, e1, e2, e3)
 
 
 # -----------------------------------------------------------------------
@@ -152,9 +183,17 @@ def weierstrassPPrime(z, e1, e2, e3):
     xp, z, e1, e2, e3 = _broadcast4(z, e1, e2, e3)
     from .ellipj import _ellipj_xp
     m     = (e2 - e3) / (e1 - e3)
-    w     = z * xp.sqrt(e1 - e3)
+    root_scale = xp.sqrt(e1 - e3)
+    K = _rf_xp(xp, xp.zeros_like(m), 1.0 - m, xp.ones_like(m))
+    omega1 = K / root_scale
+    period = xp.round(z / (2.0 * omega1))
+    z_reduced = z - 2.0 * period * omega1
+    w = z_reduced * root_scale
     sn, cn, dn, _ = _ellipj_xp(xp, w, m)
     scale = -2.0 * (e1 - e3) ** 1.5
-    pole  = xp.abs(sn) < 1e-10
+    pole_tol = 8.0 * np.finfo(np.float64).eps * xp.maximum(
+        xp.ones_like(z), xp.abs(z)
+    )
+    pole = xp.abs(z_reduced) <= pole_tol
     dP    = scale * cn * dn / xp.where(pole, xp.ones_like(sn), sn * sn * sn)
     return xp.where(pole, xp.full_like(dP, math.inf), dP)

--- a/python/elliptic/weierstrass.py
+++ b/python/elliptic/weierstrass.py
@@ -54,10 +54,10 @@ def _weierP_xp(xp, z, e1, e2, e3):
     w = z_reduced * scale
     sn, _, _, _ = _ellipj_xp(xp, w, m)
     sn2 = sn * sn
-    pole_tol = 8.0 * np.finfo(np.float64).eps * xp.maximum(
-        xp.ones_like(z), xp.abs(z)
-    )
-    pole = xp.abs(z_reduced) <= pole_tol
+    # Pole only at the exact lattice point (DLMF 23.9.2: the Laurent
+    # expansion makes every nearby representable z a huge FINITE value --
+    # P(1e-16) ~ 1e32, not Inf; a tolerance here destroys that data).
+    pole = z_reduced == 0.0
     P = e3 + (e1 - e3) / xp.where(pole, xp.ones_like(sn2), sn2)
     return xp.where(pole, xp.full_like(P, math.inf), P)
 
@@ -118,10 +118,10 @@ def _weierZ_xp(xp, z, e1, e2, e3):
     omega1, eta1, th1, th1p, _ = _lattice_theta_xp(xp, z, e1, e2, e3)
     period = xp.round(z / (2.0 * omega1))
     z_reduced = z - 2.0 * period * omega1
-    pole_tol = 8.0 * np.finfo(np.float64).eps * xp.maximum(
-        xp.ones_like(z), xp.abs(z)
-    )
-    pole = xp.abs(z_reduced) <= pole_tol
+    # Pole only at the exact lattice point (DLMF 23.9.2: the Laurent
+    # expansion makes every nearby representable z a huge FINITE value --
+    # P(1e-16) ~ 1e32, not Inf; a tolerance here destroys that data).
+    pole = z_reduced == 0.0
     ratio = th1p / xp.where(pole, xp.ones_like(th1), th1)
     Z = eta1 * z / omega1 + math.pi / (2.0 * omega1) * ratio
     return xp.where(pole, xp.full_like(Z, math.inf), Z)
@@ -191,9 +191,9 @@ def weierstrassPPrime(z, e1, e2, e3):
     w = z_reduced * root_scale
     sn, cn, dn, _ = _ellipj_xp(xp, w, m)
     scale = -2.0 * (e1 - e3) ** 1.5
-    pole_tol = 8.0 * np.finfo(np.float64).eps * xp.maximum(
-        xp.ones_like(z), xp.abs(z)
-    )
-    pole = xp.abs(z_reduced) <= pole_tol
+    # Pole only at the exact lattice point (DLMF 23.9.2: the Laurent
+    # expansion makes every nearby representable z a huge FINITE value --
+    # P(1e-16) ~ 1e32, not Inf; a tolerance here destroys that data).
+    pole = z_reduced == 0.0
     dP    = scale * cn * dn / xp.where(pole, xp.ones_like(sn), sn * sn * sn)
     return xp.where(pole, xp.full_like(dP, math.inf), dP)

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -11,6 +11,8 @@ except ImportError:
     pass
 
 try:
+    import jax
+    jax.config.update("jax_enable_x64", True)
     import jax.numpy  # noqa: F401
     BACKENDS.append("jax")
 except ImportError:

--- a/python/tests/test_backends.py
+++ b/python/tests/test_backends.py
@@ -1,0 +1,90 @@
+"""Backend smoke tests that make the Torch/JAX CI jobs exercise those paths."""
+
+import numpy as np
+import pytest
+
+import elliptic
+
+
+def _array(xp, values, *, complex_values=False):
+    if xp is np:
+        dtype = np.complex128 if complex_values else np.float64
+        return np.asarray(values, dtype=dtype)
+    if xp.__name__ == "torch":
+        dtype = xp.complex128 if complex_values else xp.float64
+        return xp.tensor(values, dtype=dtype)
+    dtype = xp.complex128 if complex_values else xp.float64
+    return xp.asarray(values, dtype=dtype)
+
+
+def _numpy(value):
+    if hasattr(value, "detach"):
+        return value.detach().cpu().numpy()
+    return np.asarray(value)
+
+
+def test_core_functions_preserve_backend_and_values(xp):
+    u = _array(xp, [0.2, 0.7, 1.1])
+    m = _array(xp, [0.2, 0.5, 0.8])
+
+    F, E, _ = elliptic.elliptic12(u, m)
+    sn, cn, dn, _ = elliptic.ellipj(u, m)
+    Pi = elliptic.elliptic3(u, m, 0.2)
+    B, D, _ = elliptic.ellipticBD(m)
+    Eu, Du, _ = elliptic.jacobiEDJ(u, m)
+
+    for value in (F, E, sn, cn, dn, Pi, B, D, Eu, Du):
+        assert _numpy(value).shape == (3,)
+        assert np.all(np.isfinite(_numpy(value)))
+
+    np.testing.assert_allclose(_numpy(sn) ** 2 + _numpy(cn) ** 2, 1.0, atol=2e-13)
+    np.testing.assert_allclose(_numpy(Eu), _numpy(u) - _numpy(m) * _numpy(Du), atol=2e-12)
+
+
+def test_auxiliary_functions_preserve_backend(xp):
+    v = _array(xp, [0.1, 0.3])
+    m = _array(xp, [0.4, 0.7])
+    q = elliptic.nomeq(m)
+    m_back = elliptic.inversenomeq(q)
+    th = elliptic.theta(3, v, m)
+    zeta = elliptic.weierstrassZeta(v, 1.0, 0.0, -1.0)
+    sigma = elliptic.weierstrassSigma(v, 1.0, 0.0, -1.0)
+    arc = elliptic.arclength_ellipse(
+        _array(xp, [2.0, 3.0]),
+        _array(xp, [3.0, 2.0]),
+        0.1,
+        _array(xp, [0.5, 0.7]),
+    )
+
+    np.testing.assert_allclose(_numpy(m_back), _numpy(m), atol=2e-13)
+    for value in (th, zeta, sigma, arc):
+        assert np.all(np.isfinite(_numpy(value)))
+
+
+def test_complex_functions_preserve_backend(xp):
+    u = _array(xp, [0.4 + 0.2j, 0.8 - 0.1j], complex_values=True)
+    m = _array(xp, [0.3, 0.7])
+    F, E, _ = elliptic.elliptic12i(u, m)
+    sn, cn, _ = elliptic.ellipji(u, m)
+    for value in (F, E, sn, cn):
+        assert np.all(np.isfinite(_numpy(value)))
+
+
+def test_jax_jit_core_paths():
+    jax = pytest.importorskip("jax")
+    jnp = pytest.importorskip("jax.numpy")
+    jax.config.update("jax_enable_x64", True)
+    u = jnp.asarray([0.2, 0.7], dtype=jnp.float64)
+
+    outputs = [
+        jax.jit(lambda x: elliptic.elliptic12(x, 0.5)[0])(u),
+        jax.jit(lambda x: elliptic.elliptic3(x, 0.5, 0.2))(u),
+        jax.jit(lambda x: elliptic.theta(3, x, 0.5))(u),
+    ]
+    # These larger graphs only need a tracing guard here; compiling the full
+    # fixed-iteration inverse/theta expansions would make this smoke test a
+    # poor CI citizen.
+    jax.make_jaxpr(lambda x: elliptic.inverselliptic2(x, 0.5))(u)
+    jax.make_jaxpr(lambda x: elliptic.weierstrassZeta(x, 1.0, 0.0, -1.0))(u)
+    jax.make_jaxpr(lambda x: elliptic.arclength_ellipse(2.0, 3.0, 0.0, x))(u)
+    assert all(np.all(np.isfinite(np.asarray(value))) for value in outputs)

--- a/python/tests/test_edge_cases.py
+++ b/python/tests/test_edge_cases.py
@@ -442,3 +442,84 @@ class TestMpmathAnchors:
             dpi = _s(elliptic.theta_prime(1, math.pi, m)[1])
             assert not math.isnan(dpi) and abs(dpi + d1) < 1e-13
             assert not math.isnan(_s(elliptic.theta_prime(2, math.pi / 2, m)[1]))
+
+
+# =====================================================================
+# Q. Adversarial-review round (external Codex + mpmath 1.4.1, dps=40).
+#    Each test is a counterexample a prior version failed.
+# =====================================================================
+class TestAdversarialRound:
+    def test_elliptic3_negative_amplitude_with_pole(self):
+        """0*Inf guard: negative phase never crossing the complete-integral pole."""
+        assert abs(_s(elliptic.elliptic3(-1.0, 0.5, 1.0)) - (-1.7319915420235269928)) < 1e-13
+        assert abs(_s(elliptic.elliptic3(-1.0, 1.0, 0.2)) - (-1.3115010674599590753)) < 1e-13
+        assert not math.isnan(_s(elliptic.elliptic3(-0.4, 1.0, 1.0)))
+
+    def test_complex_FE_small_m_series(self):
+        """A&S 17.4.11 path lost sqrt(eps/m) digits; the m^2 series is exact."""
+        assert abs(_s(elliptic.elliptic12i(0.2j, 1e-20)[0]) - 0.2j) < 1e-15
+        F, E, _ = elliptic.elliptic12i(math.pi / 2 + 0.2j, 1e-14)
+        assert abs(_s(F) - (1.5707963267949005462 + 0.20000000000000101344j)) < 1e-13
+        assert abs(_s(E) - (1.5707963267948926922 + 0.19999999999999898656j)) < 1e-13
+        F, E, _ = elliptic.elliptic12i(math.pi / 2 + 0.2j, 1e-6)
+        assert abs(_s(F) - (1.5707967194941992113 + 0.20000010134411776594j)) < 5e-12
+        assert abs(_s(E) - (1.5707959340957412894 + 0.19999989865593359446j)) < 5e-12
+        # both sides of the series threshold vs mpmath (dps=30)
+        Fa = _s(elliptic.elliptic12i(1.1 + 0.3j, 0.99e-4)[0])
+        assert abs(Fa - (1.1000153646885162 + 0.3000120622623928j)) < 1e-12
+        Fb = _s(elliptic.elliptic12i(1.1 + 0.3j, 1.01e-4)[0])
+        assert abs(Fb - (1.1000156750952820 + 0.3000123059589823j)) < 5e-12
+
+    def test_weierstrass_near_origin_finite(self):
+        """DLMF 23.9.2: only the exact lattice point is a pole; z = 1e-16 is
+        a huge FINITE value (a tolerance here used to return Inf)."""
+        assert abs(_s(elliptic.weierstrassP(1e-16, 1.0, 0.0, -1.0)) - 1e32) < 1e19
+        assert abs(_s(elliptic.weierstrassPPrime(1e-16, 1.0, 0.0, -1.0)) + 2e48) < 1e36
+        assert abs(_s(elliptic.weierstrassZeta(1e-16, 1.0, 0.0, -1.0)) - 1e16) < 1e3
+        assert math.isinf(_s(elliptic.weierstrassP(0.0, 1.0, 0.0, -1.0)))
+
+    def test_inverse_nome_all_scales(self):
+        """DLMF 20.9.1 closed form: m = (theta2/theta3)^4, exact at every scale
+        (the 64-step bisection had a 2^-64 absolute floor: m(1e-30) came back
+        2.7e-20)."""
+        assert abs(_s(elliptic.inversenomeq(1e-30)) - 1.6e-29) < 1e-41
+        assert abs(_s(elliptic.inversenomeq(1e-12)) - 1.5999999999872e-11) < 1e-24
+        for mv in (1e-8, 0.3, 0.85, 0.999):
+            assert abs(_s(elliptic.inversenomeq(np.asarray(_s(elliptic.nomeq(mv))))) - mv) \
+                < 1e-12 * max(mv, 1e-3), f"roundtrip at m={mv}"
+        # the computed upper endpoint must be accepted, not rejected
+        q_max = _s(elliptic.nomeq(np.nextafter(1.0, 0.0)))
+        assert _s(elliptic.inversenomeq(q_max)) > 0.999
+
+    def test_carlson_scale_invariance(self):
+        """DLMF 19.20: RF, RC ~ lambda^-1/2; RD, RJ ~ lambda^-3/2.  An absolute
+        branch tolerance in RC broke this at small scales (27% at 1e-20)."""
+        x, y, z, p = 1.0, 2.0, 3.0, 4.0
+        for lam in (1e-20, 1e20):
+            for fn, args, power in (
+                (elliptic.carlsonRF, (x, y, z), 0.5),
+                (elliptic.carlsonRC, (x, y), 0.5),
+                (elliptic.carlsonRD, (x, y, z), 1.5),
+                (elliptic.carlsonRJ, (x, y, z, p), 1.5),
+            ):
+                base = _s(fn(*args))
+                scaled = _s(fn(*(lam * a for a in args)))
+                want = base / lam ** power
+                assert abs(scaled - want) < 1e-10 * abs(want), f"{fn.__name__} at {lam}"
+        assert abs(_s(elliptic.carlsonRC(1e-20, 2e-20)) - 7853981633.9744830962) < 1e-4
+
+    def test_ellipticBD_nondegenerate_anchors(self):
+        """mpmath: B = (E-(1-m)K)/m, D = (K-E)/m at dps=40."""
+        rows = [(0.2, 0.8066808960371526438, 0.85294270257337535705),
+                (0.7, 0.88437375336868858245, 1.1909893819237805614),
+                (0.999, 0.99832798626015502386, 3.8428045742901420065)]
+        for m, B_ref, D_ref in rows:
+            B, D, _ = elliptic.ellipticBD(m)
+            assert abs(_s(B) - B_ref) < 1e-14, f"B({m})"
+            assert abs(_s(D) - D_ref) < 1e-13, f"D({m})"
+
+    def test_reversed_arc_intervals_signed(self):
+        """Reversal negates the arc for ellipses AND circles alike."""
+        assert abs(_s(elliptic.arclength_ellipse(2.0, 3.0, 1.0, 0.1))
+                   + _s(elliptic.arclength_ellipse(2.0, 3.0, 0.1, 1.0))) < 1e-13
+        assert abs(_s(elliptic.arclength_ellipse(2.0, 2.0, 1.0, 0.1)) - (-1.8)) < 1e-13

--- a/python/tests/test_regression_followup.py
+++ b/python/tests/test_regression_followup.py
@@ -1,0 +1,135 @@
+"""Regression coverage from the post-0d09740 deep audit."""
+
+import builtins
+import math
+
+import mpmath as mp
+import numpy as np
+import pytest
+from scipy import special
+
+import elliptic
+
+
+def _float(value):
+    return float(np.asarray(value))
+
+
+def test_m1_periods_do_not_hide_the_first_kind_pole():
+    for phi in [2.0, math.pi, 4.0, 10.0]:
+        F, E, Z = elliptic.elliptic12(phi, 1.0)
+        turns = math.floor((abs(phi) + math.pi / 2.0) / math.pi)
+        expected_E = (-1.0) ** turns * math.sin(abs(phi)) + 2.0 * turns
+        assert math.isinf(_float(F))
+        np.testing.assert_allclose(_float(E), expected_E, atol=1e-14)
+
+        Fn, En, Zn = elliptic.elliptic12(-phi, 1.0)
+        assert math.isinf(_float(Fn)) and _float(Fn) < 0
+        np.testing.assert_allclose(_float(En), -expected_E, atol=1e-14)
+        np.testing.assert_allclose(_float(Zn), -_float(Z), atol=1e-14)
+
+
+def test_ellipticbd_preserves_small_parameter_limits():
+    for m in [0.0, 1e-20, 1e-16, 1e-12, 1e-8]:
+        B, D, S = elliptic.ellipticBD(m)
+        np.testing.assert_allclose(_float(B), math.pi / 4.0, atol=2e-8)
+        np.testing.assert_allclose(_float(D), math.pi / 4.0, atol=2e-8)
+        np.testing.assert_allclose(_float(S), math.pi / 16.0, atol=2e-8)
+
+
+def test_theta_exact_and_near_endpoint_parameters():
+    v = 0.37
+    assert _float(elliptic.theta(1, v, 0.0)) == 0.0
+    assert _float(elliptic.theta(2, v, 0.0)) == 0.0
+    assert _float(elliptic.theta(3, v, 0.0)) == 1.0
+    assert _float(elliptic.theta(4, v, 0.0)) == 1.0
+
+    mp.mp.dps = 50
+    for m in [1e-20, 1e-15, np.nextafter(1.0, 0.0)]:
+        mm = mp.mpf(float(m))
+        q = mp.e ** (-mp.pi * mp.ellipk(1 - mm) / mp.ellipk(mm))
+        for j in range(1, 5):
+            expected = float(mp.jtheta(j, v, q))
+            np.testing.assert_allclose(
+                _float(elliptic.theta(j, v, m)),
+                expected,
+                rtol=2e-13,
+                atol=2e-15,
+            )
+
+
+def test_elliptic3_near_pole_uses_full_precision_carlson_form():
+    phi = np.array([1.2, 1.5, math.pi / 2.0])
+    m = np.array([0.8, 0.95, 0.9])
+    n = np.array([0.99, 0.999, 0.9999])
+    s = np.sin(phi)
+    c = np.cos(phi)
+    d2 = 1.0 - m * s**2
+    p = 1.0 - n * s**2
+    expected = (
+        s * special.elliprf(c**2, d2, 1.0)
+        + n * s**3 / 3.0 * special.elliprj(c**2, d2, 1.0, p)
+    )
+    np.testing.assert_allclose(
+        elliptic.elliptic3(phi, m, n), expected, rtol=2e-13, atol=2e-13
+    )
+
+
+def test_negative_phase_crossing_third_kind_pole_is_rejected():
+    with pytest.raises(ValueError, match="Cauchy principal-value"):
+        elliptic.elliptic3(-1.0, 0.5, 2.0)
+
+
+def test_large_argument_ellipj_near_endpoint_parameter():
+    mp.mp.dps = 70
+    u = 1_000_000.123
+    m = np.nextafter(1.0, 0.0)
+    sn, cn, dn, _ = elliptic.ellipj(u, m)
+    uu = mp.mpf(float(u))
+    mm = mp.mpf(float(m))
+    refs = [mp.ellipfun(name, uu, mm) for name in ("sn", "cn", "dn")]
+    for got, expected in zip((sn, cn, dn), refs):
+        np.testing.assert_allclose(_float(got), float(expected), rtol=2e-8, atol=2e-12)
+
+
+def test_weierstrass_near_pole_is_finite_until_the_actual_lattice_point():
+    values = elliptic.weierstrassP(np.array([0.0, 1e-11, 5e-11]), 1.0, 0.0, -1.0)
+    assert np.isinf(values[0])
+    assert np.all(np.isfinite(values[1:]))
+    np.testing.assert_allclose(values[1:], np.array([1e22, 4e20]), rtol=2e-15)
+
+    with pytest.raises(ValueError, match="real inputs only"):
+        elliptic.weierstrassP(0.2 + 0.1j, 1.0, 0.0, -1.0)
+
+
+def test_public_runtime_does_not_import_scipy(monkeypatch):
+    real_import = builtins.__import__
+
+    def reject_scipy(name, *args, **kwargs):
+        if name == "scipy" or name.startswith("scipy."):
+            raise AssertionError(f"unexpected SciPy runtime import: {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", reject_scipy)
+
+    elliptic.theta(1, 0.2, 0.5)
+    elliptic.theta_prime(1, 0.2, 0.5)
+    elliptic.jacobiThetaEta(0.2, 0.5)
+    elliptic.nomeq(0.5)
+    elliptic.inversenomeq(0.04)
+    elliptic.inverselliptic2(0.5, 0.5)
+    elliptic.elliptic12i(0.7 + 0.2j, 0.5)
+
+
+def test_arclength_ellipse_is_vectorized_and_validates_axes():
+    arcs = elliptic.arclength_ellipse(
+        np.array([5.0, 10.0, 3.0]),
+        np.array([10.0, 5.0, 3.0]),
+    )
+    np.testing.assert_allclose(
+        arcs,
+        np.array([48.44224110273839, 48.44224110273839, 6.0 * math.pi]),
+        rtol=2e-14,
+    )
+    with pytest.raises(ValueError, match="strictly positive"):
+        elliptic.arclength_ellipse(0.0, 1.0)


### PR DESCRIPTION
Follow-up audit on baseline `0d09740` (the issue #35 fix round), plus an independent adversarial review of the audit itself. The initial patch did not fully close the regression class: the #35 phase-reduction fix had not reached the MATLAB GPU kernels, and stale private copies inside `elliptic123.m` could still bypass the repaired public `elliptic12i`. A subsequent adversarial review (Codex, cross-checked against mpmath at 40–100 digits) of these very fixes produced five further counterexamples, all now fixed and regression-tested.

Full findings tables with severity and data impact: [`docs/specs/post-0d09740-regression-audit.md`](https://github.com/moiseevigor/elliptic/blob/audit/post-0d09740-regression-fixes/docs/specs/post-0d09740-regression-audit.md)

## Audit round (commits 1–4)

- **MATLAB GPU `elliptic12`/`ellipj`**: apply the same quasi-period reduction as the serial path (the #35 fix was CPU-only).
- **`elliptic123`**: retire private `elliptic12i`/`elliptic12ic` copies that preserved pre-fix behavior.
- **Python runtime is scipy-free**: theta/nome/inverse/complex functions no longer import scipy at call time; base installs work.
- **`ellipticBD` small-m cancellation**: `(K-E)/m` → Carlson `RD`/`RF` forms (at `m=1e-20`, `S` was wrong by ~1e20).
- **`elliptic12` at `m=1`**: pole crossings detected from the original phase (`F(pi,1)` returned 0).
- **JAX/PyTorch dispatch**: masked expressions and fixed iteration counts; results stay on device.
- **CI**: all 16 Octave test files (was 6/15), real NumPy/Torch/JAX dispatch jobs, scipy-free install check gating release.

## Adversarial-review round (commit 5)

| Counterexample | Fix |
|---|---|
| `elliptic3(-1, .5, 1)` → NaN (0·Inf against a complete-integral pole) | correction applied only where a half-period/reflection exists |
| `F(0.2i\|1e-20)` → 0; complex F/E lose √(eps/m) digits as m→0 (both ports) | Maclaurin series through m², crossover ~2e-12 vs mpmath |
| `weierstrassP(1e-16)` → Inf though the true value is the finite 1e32 (both ports) | pole = exact lattice point only (DLMF 23.9.2) |
| `inversenomeq(1e-30)` off by 9 orders (Python); MATLAB tables unreliable outside [1e-5, 0.76] | DLMF 20.9.1 closed form `m = (θ₂/θ₃)⁴`, exact at every scale |
| `carlsonRC(1e-20, 2e-20)` 27% off — absolute branch tolerance broke DLMF 19.20 homogeneity (Python) | relative branch selection; homogeneity tested at λ=1e±20 |

Review claims **not** adopted, with documented reasons: the m→1 complex values are the A&S 17.4.11 branch convention (now documented in both ports), and the `u=1e16` Jacobi phase loss is the double-precision reduction wall shared by every double implementation (recorded as a deliberate limit).

## Verification

- Octave: 240/240 blocks across all 16 test files.
- Python: 458 passed + 1 optional-JAX skip; backend matrix 10/10.
- 200 random complex F/E/sn samples vs 50-digit mpmath: ≤5e-14; Weierstrass DE residual ≤4.5e-15; new anchors machine-generated from mpmath at dps=40 (never hand-typed).

## Deliberate limits

GPU kernels corrected and reviewed but not hardware-run; MATLAB parallel needs a real multi-worker run before release claims; Weierstrass functions reject complex input explicitly; `elliptic3` does not implement principal-value continuation; `ellipj` phase reduction is double-precision (full accuracy to |u|~1e12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)